### PR TITLE
chore: add region tags to pom.xml instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Quickstart
 ----------
 If you are using Maven with a BOM, add this to your pom.xml file.
 ```xml
-# [START with-bom]
+<!-- START monitoring_install_with_bom] -->
 <dependencyManagement>
  <dependencies>
   <dependency>
@@ -31,18 +31,18 @@ If you are using Maven with a BOM, add this to your pom.xml file.
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring</artifactId>
 </dependency>
-# [END with-bom]
+<!-- END monitoring_install_with_bom] -->
 ```
 [//]: # ({x-version-update-start:google-cloud-monitoring:released})
 If you are using Maven without a BOM, add this to your dependencies.
 ```xml
-# [START without-bom]
+<!-- START monitoring_install_without_bom] -->
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring</artifactId>
   <version>1.99.0</version>
 </dependency>
-# [END without-bom]
+<!-- [END monitoring_install_without_bom] -->
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Quickstart
 ----------
 If you are using Maven with a BOM, add this to your pom.xml file.
 ```xml
-<!-- START monitoring_install_with_bom] -->
+<!-- [START monitoring_install_with_bom] -->
 <dependencyManagement>
  <dependencies>
   <dependency>
@@ -31,12 +31,12 @@ If you are using Maven with a BOM, add this to your pom.xml file.
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring</artifactId>
 </dependency>
-<!-- END monitoring_install_with_bom] -->
+<!-- [END monitoring_install_with_bom] -->
 ```
 [//]: # ({x-version-update-start:google-cloud-monitoring:released})
 If you are using Maven without a BOM, add this to your dependencies.
 ```xml
-<!-- START monitoring_install_without_bom] -->
+<!-- [START monitoring_install_without_bom] -->
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring</artifactId>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Quickstart
 ----------
 If you are using Maven with a BOM, add this to your pom.xml file.
 ```xml
+# [START with-bom]
 <dependencyManagement>
  <dependencies>
   <dependency>
@@ -30,15 +31,18 @@ If you are using Maven with a BOM, add this to your pom.xml file.
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring</artifactId>
 </dependency>
+# [END with-bom]
 ```
 [//]: # ({x-version-update-start:google-cloud-monitoring:released})
 If you are using Maven without a BOM, add this to your dependencies.
 ```xml
+# [START without-bom]
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring</artifactId>
   <version>1.99.0</version>
 </dependency>
+# [END without-bom]
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy


### PR DESCRIPTION
Adding these region tags so our public documentation for Java here, https://cloud.google.com/monitoring/docs/reference/libraries, matches the instructions on GitHub. See b/146068230 for reference. 