### PR TITLE
samples: import quickstart samples from java-docs-samples

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -62,17 +62,14 @@ integration)
     bash .kokoro/coerce_logs.sh
     ;;
 samples)
-    if [[ -d samples ]]
-    then
-      mvn -B \
-        -Penable-samples \
-        -DtrimStackTrace=false \
-        -Dclirr.skip=true \
-        -Denforcer.skip=true \
-        -fae \
-        verify
-      bash .kokoro/coerce_logs.sh
-    fi
+    mvn -B \
+      -Penable-samples \
+      -DtrimStackTrace=false \
+      -Dclirr.skip=true \
+      -Denforcer.skip=true \
+      -fae \
+      verify
+    bash .kokoro/coerce_logs.sh
     ;;
 clirr)
     mvn -B -Denforcer.skip=true clirr:check

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -62,14 +62,17 @@ integration)
     bash .kokoro/coerce_logs.sh
     ;;
 samples)
-    mvn -B \
-      -Penable-samples \
-      -DtrimStackTrace=false \
-      -Dclirr.skip=true \
-      -Denforcer.skip=true \
-      -fae \
-      verify
-    bash .kokoro/coerce_logs.sh
+    if [[ -d samples ]]
+    then
+      mvn -B \
+        -Penable-samples \
+        -DtrimStackTrace=false \
+        -Dclirr.skip=true \
+        -Denforcer.skip=true \
+        -fae \
+        verify
+      bash .kokoro/coerce_logs.sh
+    fi
     ;;
 clirr)
     mvn -B -Denforcer.skip=true clirr:check

--- a/google-cloud-monitoring-bom/pom.xml
+++ b/google-cloud-monitoring-bom/pom.xml
@@ -11,7 +11,7 @@
     <version>0.4.0</version>
   </parent>
 
-  <name>Google Cloud monitoring BOM</name>
+  <name>Google Cloud Monitoring BOM</name>
   <url>https://github.com/googleapis/java-monitoring</url>
   <description>
     BOM for Google Cloud Monitoring

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,8 @@
     <module>proto-google-cloud-monitoring-v3</module>
     <module>grpc-google-cloud-monitoring-v3</module>
     <module>google-cloud-monitoring</module>
-  <module>google-cloud-monitoring-bom</module>
+    <module>samples</module>
+    <module>google-cloud-monitoring-bom</module>
   </modules>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
 
   <profiles>
     <profile>
-      <id>include-samples</id>
+      <id>enable-samples</id>
       <modules>
         <module>samples</module>
       </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,6 @@
     <module>proto-google-cloud-monitoring-v3</module>
     <module>grpc-google-cloud-monitoring-v3</module>
     <module>google-cloud-monitoring</module>
-    <module>samples</module>
     <module>google-cloud-monitoring-bom</module>
   </modules>
 
@@ -254,4 +253,13 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>include-samples</id>
+      <modules>
+        <module>samples</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/samples/install-with-bom/pom.xml
+++ b/samples/install-with-bom/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-monitoring-samples</artifactId>
-    <version>0.0.0</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/samples/install-with-bom/pom.xml
+++ b/samples/install-with-bom/pom.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>monitoring-install-with-bom</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud Monitoring Install With BOM Sample</name>
+  <url>https://github.com/googleapis/java-monitoring</url>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-monitoring-samples</artifactId>
+    <version>0.0.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <!-- [START monitoring_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>3.5.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-monitoring</artifactId>
+    </dependency>
+  </dependencies>
+  <!-- [END monitoring_install_with_bom] -->
+</project>

--- a/samples/install-with-bom/src/main/java/com/example/monitoring/QuickstartSample.java
+++ b/samples/install-with-bom/src/main/java/com/example/monitoring/QuickstartSample.java
@@ -16,7 +16,7 @@
 
 package com.example.monitoring;
 
-//CHECKSTYLE OFF: VariableDeclarationUsageDistance
+// CHECKSTYLE OFF: VariableDeclarationUsageDistance
 // [START monitoring_quickstart]
 
 import com.google.api.Metric;
@@ -51,16 +51,12 @@ public class QuickstartSample {
     MetricServiceClient metricServiceClient = MetricServiceClient.create();
 
     // Prepares an individual data point
-    TimeInterval interval = TimeInterval.newBuilder()
-        .setEndTime(Timestamps.fromMillis(System.currentTimeMillis()))
-        .build();
-    TypedValue value = TypedValue.newBuilder()
-        .setDoubleValue(123.45)
-        .build();
-    Point point = Point.newBuilder()
-        .setInterval(interval)
-        .setValue(value)
-        .build();
+    TimeInterval interval =
+        TimeInterval.newBuilder()
+            .setEndTime(Timestamps.fromMillis(System.currentTimeMillis()))
+            .build();
+    TypedValue value = TypedValue.newBuilder().setDoubleValue(123.45).build();
+    Point point = Point.newBuilder().setInterval(interval).setValue(value).build();
 
     List<Point> pointList = new ArrayList<>();
     pointList.add(point);
@@ -70,32 +66,33 @@ public class QuickstartSample {
     // Prepares the metric descriptor
     Map<String, String> metricLabels = new HashMap<String, String>();
     metricLabels.put("store_id", "Pittsburg");
-    Metric metric = Metric.newBuilder()
-        .setType("custom.googleapis.com/stores/daily_sales")
-        .putAllLabels(metricLabels)
-        .build();
+    Metric metric =
+        Metric.newBuilder()
+            .setType("custom.googleapis.com/stores/daily_sales")
+            .putAllLabels(metricLabels)
+            .build();
 
     // Prepares the monitored resource descriptor
     Map<String, String> resourceLabels = new HashMap<String, String>();
     resourceLabels.put("project_id", projectId);
-    MonitoredResource resource = MonitoredResource.newBuilder()
-        .setType("global")
-        .putAllLabels(resourceLabels)
-        .build();
+    MonitoredResource resource =
+        MonitoredResource.newBuilder().setType("global").putAllLabels(resourceLabels).build();
 
     // Prepares the time series request
-    TimeSeries timeSeries = TimeSeries.newBuilder()
-        .setMetric(metric)
-        .setResource(resource)
-        .addAllPoints(pointList)
-        .build();
+    TimeSeries timeSeries =
+        TimeSeries.newBuilder()
+            .setMetric(metric)
+            .setResource(resource)
+            .addAllPoints(pointList)
+            .build();
     List<TimeSeries> timeSeriesList = new ArrayList<>();
     timeSeriesList.add(timeSeries);
 
-    CreateTimeSeriesRequest request = CreateTimeSeriesRequest.newBuilder()
-        .setName(name.toString())
-        .addAllTimeSeries(timeSeriesList)
-        .build();
+    CreateTimeSeriesRequest request =
+        CreateTimeSeriesRequest.newBuilder()
+            .setName(name.toString())
+            .addAllTimeSeries(timeSeriesList)
+            .build();
 
     // Writes time series data
     metricServiceClient.createTimeSeries(request);
@@ -106,4 +103,4 @@ public class QuickstartSample {
   }
 }
 // [END monitoring_quickstart]
-//CHECKSTYLE ON: VariableDeclarationUsageDistance
+// CHECKSTYLE ON: VariableDeclarationUsageDistance

--- a/samples/install-with-bom/src/main/java/com/example/monitoring/QuickstartSample.java
+++ b/samples/install-with-bom/src/main/java/com/example/monitoring/QuickstartSample.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.monitoring;
+
+//CHECKSTYLE OFF: VariableDeclarationUsageDistance
+// [START monitoring_quickstart]
+
+import com.google.api.Metric;
+import com.google.api.MonitoredResource;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.monitoring.v3.CreateTimeSeriesRequest;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.util.Timestamps;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Imports the Google Cloud client library
+
+public class QuickstartSample {
+
+  public static void main(String... args) throws Exception {
+    // Your Google Cloud Platform project ID
+    String projectId = System.getProperty("projectId");
+
+    if (projectId == null) {
+      System.err.println("Usage: QuickstartSample -DprojectId=YOUR_PROJECT_ID");
+      return;
+    }
+
+    // Instantiates a client
+    MetricServiceClient metricServiceClient = MetricServiceClient.create();
+
+    // Prepares an individual data point
+    TimeInterval interval = TimeInterval.newBuilder()
+        .setEndTime(Timestamps.fromMillis(System.currentTimeMillis()))
+        .build();
+    TypedValue value = TypedValue.newBuilder()
+        .setDoubleValue(123.45)
+        .build();
+    Point point = Point.newBuilder()
+        .setInterval(interval)
+        .setValue(value)
+        .build();
+
+    List<Point> pointList = new ArrayList<>();
+    pointList.add(point);
+
+    ProjectName name = ProjectName.of(projectId);
+
+    // Prepares the metric descriptor
+    Map<String, String> metricLabels = new HashMap<String, String>();
+    metricLabels.put("store_id", "Pittsburg");
+    Metric metric = Metric.newBuilder()
+        .setType("custom.googleapis.com/stores/daily_sales")
+        .putAllLabels(metricLabels)
+        .build();
+
+    // Prepares the monitored resource descriptor
+    Map<String, String> resourceLabels = new HashMap<String, String>();
+    resourceLabels.put("project_id", projectId);
+    MonitoredResource resource = MonitoredResource.newBuilder()
+        .setType("global")
+        .putAllLabels(resourceLabels)
+        .build();
+
+    // Prepares the time series request
+    TimeSeries timeSeries = TimeSeries.newBuilder()
+        .setMetric(metric)
+        .setResource(resource)
+        .addAllPoints(pointList)
+        .build();
+    List<TimeSeries> timeSeriesList = new ArrayList<>();
+    timeSeriesList.add(timeSeries);
+
+    CreateTimeSeriesRequest request = CreateTimeSeriesRequest.newBuilder()
+        .setName(name.toString())
+        .addAllTimeSeries(timeSeriesList)
+        .build();
+
+    // Writes time series data
+    metricServiceClient.createTimeSeries(request);
+
+    System.out.printf("Done writing time series data.%n");
+
+    metricServiceClient.close();
+  }
+}
+// [END monitoring_quickstart]
+//CHECKSTYLE ON: VariableDeclarationUsageDistance

--- a/samples/install-with-bom/src/test/java/com/example/monitoring/QuickstartSampleIT.java
+++ b/samples/install-with-bom/src/test/java/com/example/monitoring/QuickstartSampleIT.java
@@ -26,9 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for quickstart sample.
- */
+/** Tests for quickstart sample. */
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class QuickstartSampleIT {
@@ -40,8 +38,8 @@ public class QuickstartSampleIT {
   private static String getProjectId() {
     String projectId = System.getProperty(PROJECT_ENV_NAME, System.getenv(PROJECT_ENV_NAME));
     if (projectId == null) {
-      projectId = System.getProperty(LEGACY_PROJECT_ENV_NAME,
-          System.getenv(LEGACY_PROJECT_ENV_NAME));
+      projectId =
+          System.getProperty(LEGACY_PROJECT_ENV_NAME, System.getenv(LEGACY_PROJECT_ENV_NAME));
     }
     return projectId;
   }

--- a/samples/install-with-bom/src/test/java/com/example/monitoring/QuickstartSampleIT.java
+++ b/samples/install-with-bom/src/test/java/com/example/monitoring/QuickstartSampleIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.monitoring;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for quickstart sample.
+ */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class QuickstartSampleIT {
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
+  private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+
+  private static String getProjectId() {
+    String projectId = System.getProperty(PROJECT_ENV_NAME, System.getenv(PROJECT_ENV_NAME));
+    if (projectId == null) {
+      projectId = System.getProperty(LEGACY_PROJECT_ENV_NAME,
+          System.getenv(LEGACY_PROJECT_ENV_NAME));
+    }
+    return projectId;
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(null);
+  }
+
+  @Test
+  public void testQuickstart() throws Exception {
+    // Act
+    System.setProperty("projectId", QuickstartSampleIT.getProjectId());
+    QuickstartSample.main();
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains("Done writing time series data.");
+  }
+}

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -12,9 +12,9 @@
     Removing or replacing it should not affect the execution of the samples in anyway.
   -->
   <parent>
-    <groupId>com.google.cloud.samples</groupId>
-    <artifactId>shared-configuration</artifactId>
-    <version>1.0.11</version>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-monitoring-samples</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>monitoring-install-without-bom</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud Monitoring Install Without BOM Sample</name>
+  <url>https://github.com/googleapis/java-monitoring</url>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.11</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <!-- {x-version-update-start:google-cloud-monitoring:released} -->
+  <dependencies>
+    <!-- [START monitoring_install_without_bom] -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-monitoring</artifactId>
+      <version>1.99.2</version>
+    </dependency>
+    <!-- [END monitoring_install_without_bom] -->
+  </dependencies>
+  <!-- {x-version-update-end} -->
+
+</project>

--- a/samples/install-without-bom/src/main/java/com/example/monitoring/QuickstartSample.java
+++ b/samples/install-without-bom/src/main/java/com/example/monitoring/QuickstartSample.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.monitoring;
+
+// CHECKSTYLE OFF: VariableDeclarationUsageDistance
+// [START monitoring_quickstart]
+
+import com.google.api.Metric;
+import com.google.api.MonitoredResource;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.monitoring.v3.CreateTimeSeriesRequest;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.util.Timestamps;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Imports the Google Cloud client library
+
+public class QuickstartSample {
+
+  public static void main(String... args) throws Exception {
+    // Your Google Cloud Platform project ID
+    String projectId = System.getProperty("projectId");
+
+    if (projectId == null) {
+      System.err.println("Usage: QuickstartSample -DprojectId=YOUR_PROJECT_ID");
+      return;
+    }
+
+    // Instantiates a client
+    MetricServiceClient metricServiceClient = MetricServiceClient.create();
+
+    // Prepares an individual data point
+    TimeInterval interval =
+        TimeInterval.newBuilder()
+            .setEndTime(Timestamps.fromMillis(System.currentTimeMillis()))
+            .build();
+    TypedValue value = TypedValue.newBuilder().setDoubleValue(123.45).build();
+    Point point = Point.newBuilder().setInterval(interval).setValue(value).build();
+
+    List<Point> pointList = new ArrayList<>();
+    pointList.add(point);
+
+    ProjectName name = ProjectName.of(projectId);
+
+    // Prepares the metric descriptor
+    Map<String, String> metricLabels = new HashMap<String, String>();
+    metricLabels.put("store_id", "Pittsburg");
+    Metric metric =
+        Metric.newBuilder()
+            .setType("custom.googleapis.com/stores/daily_sales")
+            .putAllLabels(metricLabels)
+            .build();
+
+    // Prepares the monitored resource descriptor
+    Map<String, String> resourceLabels = new HashMap<String, String>();
+    resourceLabels.put("project_id", projectId);
+    MonitoredResource resource =
+        MonitoredResource.newBuilder().setType("global").putAllLabels(resourceLabels).build();
+
+    // Prepares the time series request
+    TimeSeries timeSeries =
+        TimeSeries.newBuilder()
+            .setMetric(metric)
+            .setResource(resource)
+            .addAllPoints(pointList)
+            .build();
+    List<TimeSeries> timeSeriesList = new ArrayList<>();
+    timeSeriesList.add(timeSeries);
+
+    CreateTimeSeriesRequest request =
+        CreateTimeSeriesRequest.newBuilder()
+            .setName(name.toString())
+            .addAllTimeSeries(timeSeriesList)
+            .build();
+
+    // Writes time series data
+    metricServiceClient.createTimeSeries(request);
+
+    System.out.printf("Done writing time series data.%n");
+
+    metricServiceClient.close();
+  }
+}
+// [END monitoring_quickstart]
+// CHECKSTYLE ON: VariableDeclarationUsageDistance

--- a/samples/install-without-bom/src/test/java/com/example/monitoring/QuickstartSampleIT.java
+++ b/samples/install-without-bom/src/test/java/com/example/monitoring/QuickstartSampleIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.monitoring;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for quickstart sample. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class QuickstartSampleIT {
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
+  private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+
+  private static String getProjectId() {
+    String projectId = System.getProperty(PROJECT_ENV_NAME, System.getenv(PROJECT_ENV_NAME));
+    if (projectId == null) {
+      projectId =
+          System.getProperty(LEGACY_PROJECT_ENV_NAME, System.getenv(LEGACY_PROJECT_ENV_NAME));
+    }
+    return projectId;
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(null);
+  }
+
+  @Test
+  public void testQuickstart() throws Exception {
+    // Act
+    System.setProperty("projectId", QuickstartSampleIT.getProjectId());
+    QuickstartSample.main();
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains("Done writing time series data.");
+  }
+}

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-monitoring-samples</artifactId>
+  <version>0.0.0</version>
+  <packaging>pom</packaging>
+  <name>Google Cloud Monitoring Samples Parent</name>
+  <url>https://github.com/googleapis/java-monitoring</url>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.11</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>install-with-bom</module>
+    <module>install-without-bom</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.0.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-monitoring-samples</artifactId>
-  <version>0.0.0</version>
+  <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released -->
   <packaging>pom</packaging>
   <name>Google Cloud Monitoring Samples Parent</name>
   <url>https://github.com/googleapis/java-monitoring</url>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -33,6 +33,17 @@
   </modules>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Also provides snippets for the installation options for installing with the `libraries-bom` and without the `libraries-bom`.

Note that there are snippets in `samples/install-with-bom/pom.xml` and `samples/install-without-bom/pom.xml` which are usable by cloud.google.com rather than using the snippets from the README. synthtool will [be able to use the snippet](https://github.com/googleapis/synthtool/pull/406) as well in order to generate the README. renovate-bot will be able to update both of the install `pom.xml` files with the latest `libraries-bom` version and `google-cloud-montoring` version if necessary.