### PR TITLE
chore: Migrate monitoring synth.py to bazel

### DIFF
--- a/grpc-google-cloud-monitoring-v3/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-monitoring-v3/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/monitoring/v3/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/AlertPolicyServiceGrpc.java
+++ b/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/AlertPolicyServiceGrpc.java
@@ -38,7 +38,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/monitoring/v3/alert_service.proto")
 public final class AlertPolicyServiceGrpc {
 
@@ -47,30 +47,20 @@ public final class AlertPolicyServiceGrpc {
   public static final String SERVICE_NAME = "google.monitoring.v3.AlertPolicyService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListAlertPoliciesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListAlertPoliciesRequest,
-          com.google.monitoring.v3.ListAlertPoliciesResponse>
-      METHOD_LIST_ALERT_POLICIES = getListAlertPoliciesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListAlertPoliciesRequest,
           com.google.monitoring.v3.ListAlertPoliciesResponse>
       getListAlertPoliciesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListAlertPolicies",
+      requestType = com.google.monitoring.v3.ListAlertPoliciesRequest.class,
+      responseType = com.google.monitoring.v3.ListAlertPoliciesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListAlertPoliciesRequest,
           com.google.monitoring.v3.ListAlertPoliciesResponse>
       getListAlertPoliciesMethod() {
-    return getListAlertPoliciesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListAlertPoliciesRequest,
-          com.google.monitoring.v3.ListAlertPoliciesResponse>
-      getListAlertPoliciesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListAlertPoliciesRequest,
             com.google.monitoring.v3.ListAlertPoliciesResponse>
@@ -86,9 +76,7 @@ public final class AlertPolicyServiceGrpc {
                           com.google.monitoring.v3.ListAlertPoliciesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.AlertPolicyService", "ListAlertPolicies"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListAlertPolicies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -107,26 +95,18 @@ public final class AlertPolicyServiceGrpc {
     return getListAlertPoliciesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAlertPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
-      METHOD_GET_ALERT_POLICY = getGetAlertPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
       getGetAlertPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAlertPolicy",
+      requestType = com.google.monitoring.v3.GetAlertPolicyRequest.class,
+      responseType = com.google.monitoring.v3.AlertPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
       getGetAlertPolicyMethod() {
-    return getGetAlertPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
-      getGetAlertPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
         getGetAlertPolicyMethod;
@@ -140,9 +120,7 @@ public final class AlertPolicyServiceGrpc {
                           com.google.monitoring.v3.AlertPolicy>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.AlertPolicyService", "GetAlertPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetAlertPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -159,26 +137,18 @@ public final class AlertPolicyServiceGrpc {
     return getGetAlertPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateAlertPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
-      METHOD_CREATE_ALERT_POLICY = getCreateAlertPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
       getCreateAlertPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateAlertPolicy",
+      requestType = com.google.monitoring.v3.CreateAlertPolicyRequest.class,
+      responseType = com.google.monitoring.v3.AlertPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
       getCreateAlertPolicyMethod() {
-    return getCreateAlertPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
-      getCreateAlertPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
         getCreateAlertPolicyMethod;
@@ -193,9 +163,7 @@ public final class AlertPolicyServiceGrpc {
                           com.google.monitoring.v3.AlertPolicy>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.AlertPolicyService", "CreateAlertPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateAlertPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -213,26 +181,18 @@ public final class AlertPolicyServiceGrpc {
     return getCreateAlertPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAlertPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteAlertPolicyRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ALERT_POLICY = getDeleteAlertPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteAlertPolicyRequest, com.google.protobuf.Empty>
       getDeleteAlertPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAlertPolicy",
+      requestType = com.google.monitoring.v3.DeleteAlertPolicyRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteAlertPolicyRequest, com.google.protobuf.Empty>
       getDeleteAlertPolicyMethod() {
-    return getDeleteAlertPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteAlertPolicyRequest, com.google.protobuf.Empty>
-      getDeleteAlertPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.DeleteAlertPolicyRequest, com.google.protobuf.Empty>
         getDeleteAlertPolicyMethod;
@@ -247,9 +207,7 @@ public final class AlertPolicyServiceGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.AlertPolicyService", "DeleteAlertPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteAlertPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -267,26 +225,18 @@ public final class AlertPolicyServiceGrpc {
     return getDeleteAlertPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateAlertPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
-      METHOD_UPDATE_ALERT_POLICY = getUpdateAlertPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
       getUpdateAlertPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateAlertPolicy",
+      requestType = com.google.monitoring.v3.UpdateAlertPolicyRequest.class,
+      responseType = com.google.monitoring.v3.AlertPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
       getUpdateAlertPolicyMethod() {
-    return getUpdateAlertPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
-      getUpdateAlertPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.UpdateAlertPolicyRequest, com.google.monitoring.v3.AlertPolicy>
         getUpdateAlertPolicyMethod;
@@ -301,9 +251,7 @@ public final class AlertPolicyServiceGrpc {
                           com.google.monitoring.v3.AlertPolicy>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.AlertPolicyService", "UpdateAlertPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateAlertPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -323,19 +271,43 @@ public final class AlertPolicyServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AlertPolicyServiceStub newStub(io.grpc.Channel channel) {
-    return new AlertPolicyServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AlertPolicyServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AlertPolicyServiceStub>() {
+          @java.lang.Override
+          public AlertPolicyServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AlertPolicyServiceStub(channel, callOptions);
+          }
+        };
+    return AlertPolicyServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AlertPolicyServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AlertPolicyServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AlertPolicyServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AlertPolicyServiceBlockingStub>() {
+          @java.lang.Override
+          public AlertPolicyServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AlertPolicyServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AlertPolicyServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AlertPolicyServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AlertPolicyServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AlertPolicyServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AlertPolicyServiceFutureStub>() {
+          @java.lang.Override
+          public AlertPolicyServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AlertPolicyServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AlertPolicyServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -366,7 +338,7 @@ public final class AlertPolicyServiceGrpc {
         com.google.monitoring.v3.ListAlertPoliciesRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListAlertPoliciesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListAlertPoliciesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListAlertPoliciesMethod(), responseObserver);
     }
 
     /**
@@ -379,7 +351,7 @@ public final class AlertPolicyServiceGrpc {
     public void getAlertPolicy(
         com.google.monitoring.v3.GetAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.AlertPolicy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAlertPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAlertPolicyMethod(), responseObserver);
     }
 
     /**
@@ -392,7 +364,7 @@ public final class AlertPolicyServiceGrpc {
     public void createAlertPolicy(
         com.google.monitoring.v3.CreateAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.AlertPolicy> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateAlertPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateAlertPolicyMethod(), responseObserver);
     }
 
     /**
@@ -405,7 +377,7 @@ public final class AlertPolicyServiceGrpc {
     public void deleteAlertPolicy(
         com.google.monitoring.v3.DeleteAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAlertPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAlertPolicyMethod(), responseObserver);
     }
 
     /**
@@ -421,39 +393,39 @@ public final class AlertPolicyServiceGrpc {
     public void updateAlertPolicy(
         com.google.monitoring.v3.UpdateAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.AlertPolicy> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateAlertPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateAlertPolicyMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListAlertPoliciesMethodHelper(),
+              getListAlertPoliciesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListAlertPoliciesRequest,
                       com.google.monitoring.v3.ListAlertPoliciesResponse>(
                       this, METHODID_LIST_ALERT_POLICIES)))
           .addMethod(
-              getGetAlertPolicyMethodHelper(),
+              getGetAlertPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetAlertPolicyRequest,
                       com.google.monitoring.v3.AlertPolicy>(this, METHODID_GET_ALERT_POLICY)))
           .addMethod(
-              getCreateAlertPolicyMethodHelper(),
+              getCreateAlertPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateAlertPolicyRequest,
                       com.google.monitoring.v3.AlertPolicy>(this, METHODID_CREATE_ALERT_POLICY)))
           .addMethod(
-              getDeleteAlertPolicyMethodHelper(),
+              getDeleteAlertPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteAlertPolicyRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_ALERT_POLICY)))
           .addMethod(
-              getUpdateAlertPolicyMethodHelper(),
+              getUpdateAlertPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.UpdateAlertPolicyRequest,
@@ -478,11 +450,7 @@ public final class AlertPolicyServiceGrpc {
    * </pre>
    */
   public static final class AlertPolicyServiceStub
-      extends io.grpc.stub.AbstractStub<AlertPolicyServiceStub> {
-    private AlertPolicyServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<AlertPolicyServiceStub> {
     private AlertPolicyServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -505,7 +473,7 @@ public final class AlertPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListAlertPoliciesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListAlertPoliciesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListAlertPoliciesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -521,7 +489,7 @@ public final class AlertPolicyServiceGrpc {
         com.google.monitoring.v3.GetAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.AlertPolicy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAlertPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetAlertPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -537,7 +505,7 @@ public final class AlertPolicyServiceGrpc {
         com.google.monitoring.v3.CreateAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.AlertPolicy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateAlertPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateAlertPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -553,7 +521,7 @@ public final class AlertPolicyServiceGrpc {
         com.google.monitoring.v3.DeleteAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAlertPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAlertPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -572,7 +540,7 @@ public final class AlertPolicyServiceGrpc {
         com.google.monitoring.v3.UpdateAlertPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.AlertPolicy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateAlertPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateAlertPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -594,11 +562,7 @@ public final class AlertPolicyServiceGrpc {
    * </pre>
    */
   public static final class AlertPolicyServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AlertPolicyServiceBlockingStub> {
-    private AlertPolicyServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AlertPolicyServiceBlockingStub> {
     private AlertPolicyServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -620,7 +584,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.monitoring.v3.ListAlertPoliciesResponse listAlertPolicies(
         com.google.monitoring.v3.ListAlertPoliciesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListAlertPoliciesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListAlertPoliciesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -632,8 +596,7 @@ public final class AlertPolicyServiceGrpc {
      */
     public com.google.monitoring.v3.AlertPolicy getAlertPolicy(
         com.google.monitoring.v3.GetAlertPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetAlertPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetAlertPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -646,7 +609,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.monitoring.v3.AlertPolicy createAlertPolicy(
         com.google.monitoring.v3.CreateAlertPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateAlertPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateAlertPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -659,7 +622,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.protobuf.Empty deleteAlertPolicy(
         com.google.monitoring.v3.DeleteAlertPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteAlertPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteAlertPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -675,7 +638,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.monitoring.v3.AlertPolicy updateAlertPolicy(
         com.google.monitoring.v3.UpdateAlertPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateAlertPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateAlertPolicyMethod(), getCallOptions(), request);
     }
   }
 
@@ -695,11 +658,7 @@ public final class AlertPolicyServiceGrpc {
    * </pre>
    */
   public static final class AlertPolicyServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AlertPolicyServiceFutureStub> {
-    private AlertPolicyServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AlertPolicyServiceFutureStub> {
     private AlertPolicyServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -721,7 +680,7 @@ public final class AlertPolicyServiceGrpc {
             com.google.monitoring.v3.ListAlertPoliciesResponse>
         listAlertPolicies(com.google.monitoring.v3.ListAlertPoliciesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListAlertPoliciesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListAlertPoliciesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -734,7 +693,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.AlertPolicy>
         getAlertPolicy(com.google.monitoring.v3.GetAlertPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetAlertPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetAlertPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -747,7 +706,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.AlertPolicy>
         createAlertPolicy(com.google.monitoring.v3.CreateAlertPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateAlertPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateAlertPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -760,7 +719,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteAlertPolicy(com.google.monitoring.v3.DeleteAlertPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAlertPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteAlertPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -776,7 +735,7 @@ public final class AlertPolicyServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.AlertPolicy>
         updateAlertPolicy(com.google.monitoring.v3.UpdateAlertPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateAlertPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateAlertPolicyMethod(), getCallOptions()), request);
     }
   }
 
@@ -893,11 +852,11 @@ public final class AlertPolicyServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AlertPolicyServiceFileDescriptorSupplier())
-                      .addMethod(getListAlertPoliciesMethodHelper())
-                      .addMethod(getGetAlertPolicyMethodHelper())
-                      .addMethod(getCreateAlertPolicyMethodHelper())
-                      .addMethod(getDeleteAlertPolicyMethodHelper())
-                      .addMethod(getUpdateAlertPolicyMethodHelper())
+                      .addMethod(getListAlertPoliciesMethod())
+                      .addMethod(getGetAlertPolicyMethod())
+                      .addMethod(getCreateAlertPolicyMethod())
+                      .addMethod(getDeleteAlertPolicyMethod())
+                      .addMethod(getUpdateAlertPolicyMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/GroupServiceGrpc.java
+++ b/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/GroupServiceGrpc.java
@@ -40,7 +40,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/monitoring/v3/group_service.proto")
 public final class GroupServiceGrpc {
 
@@ -49,26 +49,18 @@ public final class GroupServiceGrpc {
   public static final String SERVICE_NAME = "google.monitoring.v3.GroupService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListGroupsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListGroupsRequest, com.google.monitoring.v3.ListGroupsResponse>
-      METHOD_LIST_GROUPS = getListGroupsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListGroupsRequest, com.google.monitoring.v3.ListGroupsResponse>
       getListGroupsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListGroups",
+      requestType = com.google.monitoring.v3.ListGroupsRequest.class,
+      responseType = com.google.monitoring.v3.ListGroupsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListGroupsRequest, com.google.monitoring.v3.ListGroupsResponse>
       getListGroupsMethod() {
-    return getListGroupsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListGroupsRequest, com.google.monitoring.v3.ListGroupsResponse>
-      getListGroupsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListGroupsRequest, com.google.monitoring.v3.ListGroupsResponse>
         getListGroupsMethod;
@@ -82,8 +74,7 @@ public final class GroupServiceGrpc {
                           com.google.monitoring.v3.ListGroupsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.monitoring.v3.GroupService", "ListGroups"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListGroups"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -99,26 +90,18 @@ public final class GroupServiceGrpc {
     return getListGroupsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>
-      METHOD_GET_GROUP = getGetGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>
       getGetGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetGroup",
+      requestType = com.google.monitoring.v3.GetGroupRequest.class,
+      responseType = com.google.monitoring.v3.Group.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>
       getGetGroupMethod() {
-    return getGetGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>
-      getGetGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>
         getGetGroupMethod;
@@ -131,8 +114,7 @@ public final class GroupServiceGrpc {
                       .<com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.monitoring.v3.GroupService", "GetGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -148,26 +130,18 @@ public final class GroupServiceGrpc {
     return getGetGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>
-      METHOD_CREATE_GROUP = getCreateGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>
       getCreateGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateGroup",
+      requestType = com.google.monitoring.v3.CreateGroupRequest.class,
+      responseType = com.google.monitoring.v3.Group.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>
       getCreateGroupMethod() {
-    return getCreateGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>
-      getCreateGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>
         getCreateGroupMethod;
@@ -180,9 +154,7 @@ public final class GroupServiceGrpc {
                       .<com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.GroupService", "CreateGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -198,26 +170,18 @@ public final class GroupServiceGrpc {
     return getCreateGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>
-      METHOD_UPDATE_GROUP = getUpdateGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>
       getUpdateGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateGroup",
+      requestType = com.google.monitoring.v3.UpdateGroupRequest.class,
+      responseType = com.google.monitoring.v3.Group.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>
       getUpdateGroupMethod() {
-    return getUpdateGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>
-      getUpdateGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>
         getUpdateGroupMethod;
@@ -230,9 +194,7 @@ public final class GroupServiceGrpc {
                       .<com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.GroupService", "UpdateGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -248,26 +210,18 @@ public final class GroupServiceGrpc {
     return getUpdateGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_GROUP = getDeleteGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>
       getDeleteGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteGroup",
+      requestType = com.google.monitoring.v3.DeleteGroupRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>
       getDeleteGroupMethod() {
-    return getDeleteGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>
-      getDeleteGroupMethodHelper() {
     io.grpc.MethodDescriptor<com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>
         getDeleteGroupMethod;
     if ((getDeleteGroupMethod = GroupServiceGrpc.getDeleteGroupMethod) == null) {
@@ -279,9 +233,7 @@ public final class GroupServiceGrpc {
                       .<com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.GroupService", "DeleteGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -297,30 +249,20 @@ public final class GroupServiceGrpc {
     return getDeleteGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListGroupMembersMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListGroupMembersRequest,
-          com.google.monitoring.v3.ListGroupMembersResponse>
-      METHOD_LIST_GROUP_MEMBERS = getListGroupMembersMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListGroupMembersRequest,
           com.google.monitoring.v3.ListGroupMembersResponse>
       getListGroupMembersMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListGroupMembers",
+      requestType = com.google.monitoring.v3.ListGroupMembersRequest.class,
+      responseType = com.google.monitoring.v3.ListGroupMembersResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListGroupMembersRequest,
           com.google.monitoring.v3.ListGroupMembersResponse>
       getListGroupMembersMethod() {
-    return getListGroupMembersMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListGroupMembersRequest,
-          com.google.monitoring.v3.ListGroupMembersResponse>
-      getListGroupMembersMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListGroupMembersRequest,
             com.google.monitoring.v3.ListGroupMembersResponse>
@@ -335,9 +277,7 @@ public final class GroupServiceGrpc {
                           com.google.monitoring.v3.ListGroupMembersResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.GroupService", "ListGroupMembers"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListGroupMembers"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -358,19 +298,43 @@ public final class GroupServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static GroupServiceStub newStub(io.grpc.Channel channel) {
-    return new GroupServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<GroupServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<GroupServiceStub>() {
+          @java.lang.Override
+          public GroupServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GroupServiceStub(channel, callOptions);
+          }
+        };
+    return GroupServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static GroupServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new GroupServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<GroupServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<GroupServiceBlockingStub>() {
+          @java.lang.Override
+          public GroupServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GroupServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return GroupServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static GroupServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new GroupServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<GroupServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<GroupServiceFutureStub>() {
+          @java.lang.Override
+          public GroupServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GroupServiceFutureStub(channel, callOptions);
+          }
+        };
+    return GroupServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -402,7 +366,7 @@ public final class GroupServiceGrpc {
     public void listGroups(
         com.google.monitoring.v3.ListGroupsRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListGroupsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getListGroupsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListGroupsMethod(), responseObserver);
     }
 
     /**
@@ -415,7 +379,7 @@ public final class GroupServiceGrpc {
     public void getGroup(
         com.google.monitoring.v3.GetGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Group> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetGroupMethod(), responseObserver);
     }
 
     /**
@@ -428,7 +392,7 @@ public final class GroupServiceGrpc {
     public void createGroup(
         com.google.monitoring.v3.CreateGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Group> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateGroupMethod(), responseObserver);
     }
 
     /**
@@ -442,7 +406,7 @@ public final class GroupServiceGrpc {
     public void updateGroup(
         com.google.monitoring.v3.UpdateGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Group> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateGroupMethod(), responseObserver);
     }
 
     /**
@@ -455,7 +419,7 @@ public final class GroupServiceGrpc {
     public void deleteGroup(
         com.google.monitoring.v3.DeleteGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteGroupMethod(), responseObserver);
     }
 
     /**
@@ -469,44 +433,44 @@ public final class GroupServiceGrpc {
         com.google.monitoring.v3.ListGroupMembersRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListGroupMembersResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListGroupMembersMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListGroupMembersMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListGroupsMethodHelper(),
+              getListGroupsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListGroupsRequest,
                       com.google.monitoring.v3.ListGroupsResponse>(this, METHODID_LIST_GROUPS)))
           .addMethod(
-              getGetGroupMethodHelper(),
+              getGetGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetGroupRequest, com.google.monitoring.v3.Group>(
                       this, METHODID_GET_GROUP)))
           .addMethod(
-              getCreateGroupMethodHelper(),
+              getCreateGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateGroupRequest, com.google.monitoring.v3.Group>(
                       this, METHODID_CREATE_GROUP)))
           .addMethod(
-              getUpdateGroupMethodHelper(),
+              getUpdateGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.UpdateGroupRequest, com.google.monitoring.v3.Group>(
                       this, METHODID_UPDATE_GROUP)))
           .addMethod(
-              getDeleteGroupMethodHelper(),
+              getDeleteGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteGroupRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_GROUP)))
           .addMethod(
-              getListGroupMembersMethodHelper(),
+              getListGroupMembersMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListGroupMembersRequest,
@@ -533,11 +497,8 @@ public final class GroupServiceGrpc {
    * from the infrastructure.
    * </pre>
    */
-  public static final class GroupServiceStub extends io.grpc.stub.AbstractStub<GroupServiceStub> {
-    private GroupServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class GroupServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<GroupServiceStub> {
     private GroupServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -558,9 +519,7 @@ public final class GroupServiceGrpc {
         com.google.monitoring.v3.ListGroupsRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListGroupsResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListGroupsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListGroupsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -574,9 +533,7 @@ public final class GroupServiceGrpc {
         com.google.monitoring.v3.GetGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Group> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetGroupMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetGroupMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -590,7 +547,7 @@ public final class GroupServiceGrpc {
         com.google.monitoring.v3.CreateGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Group> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -607,7 +564,7 @@ public final class GroupServiceGrpc {
         com.google.monitoring.v3.UpdateGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Group> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -623,7 +580,7 @@ public final class GroupServiceGrpc {
         com.google.monitoring.v3.DeleteGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -640,7 +597,7 @@ public final class GroupServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListGroupMembersResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListGroupMembersMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListGroupMembersMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -664,11 +621,7 @@ public final class GroupServiceGrpc {
    * </pre>
    */
   public static final class GroupServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<GroupServiceBlockingStub> {
-    private GroupServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<GroupServiceBlockingStub> {
     private GroupServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -688,8 +641,7 @@ public final class GroupServiceGrpc {
      */
     public com.google.monitoring.v3.ListGroupsResponse listGroups(
         com.google.monitoring.v3.ListGroupsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListGroupsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListGroupsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -701,7 +653,7 @@ public final class GroupServiceGrpc {
      */
     public com.google.monitoring.v3.Group getGroup(
         com.google.monitoring.v3.GetGroupRequest request) {
-      return blockingUnaryCall(getChannel(), getGetGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -713,8 +665,7 @@ public final class GroupServiceGrpc {
      */
     public com.google.monitoring.v3.Group createGroup(
         com.google.monitoring.v3.CreateGroupRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -727,8 +678,7 @@ public final class GroupServiceGrpc {
      */
     public com.google.monitoring.v3.Group updateGroup(
         com.google.monitoring.v3.UpdateGroupRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -740,8 +690,7 @@ public final class GroupServiceGrpc {
      */
     public com.google.protobuf.Empty deleteGroup(
         com.google.monitoring.v3.DeleteGroupRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -754,7 +703,7 @@ public final class GroupServiceGrpc {
     public com.google.monitoring.v3.ListGroupMembersResponse listGroupMembers(
         com.google.monitoring.v3.ListGroupMembersRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListGroupMembersMethodHelper(), getCallOptions(), request);
+          getChannel(), getListGroupMembersMethod(), getCallOptions(), request);
     }
   }
 
@@ -776,11 +725,7 @@ public final class GroupServiceGrpc {
    * </pre>
    */
   public static final class GroupServiceFutureStub
-      extends io.grpc.stub.AbstractStub<GroupServiceFutureStub> {
-    private GroupServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<GroupServiceFutureStub> {
     private GroupServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -802,7 +747,7 @@ public final class GroupServiceGrpc {
             com.google.monitoring.v3.ListGroupsResponse>
         listGroups(com.google.monitoring.v3.ListGroupsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListGroupsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListGroupsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -814,8 +759,7 @@ public final class GroupServiceGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.Group>
         getGroup(com.google.monitoring.v3.GetGroupRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetGroupMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -828,7 +772,7 @@ public final class GroupServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.Group>
         createGroup(com.google.monitoring.v3.CreateGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -842,7 +786,7 @@ public final class GroupServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.Group>
         updateGroup(com.google.monitoring.v3.UpdateGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -855,7 +799,7 @@ public final class GroupServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteGroup(com.google.monitoring.v3.DeleteGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -869,7 +813,7 @@ public final class GroupServiceGrpc {
             com.google.monitoring.v3.ListGroupMembersResponse>
         listGroupMembers(com.google.monitoring.v3.ListGroupMembersRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListGroupMembersMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListGroupMembersMethod(), getCallOptions()), request);
     }
   }
 
@@ -993,12 +937,12 @@ public final class GroupServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new GroupServiceFileDescriptorSupplier())
-                      .addMethod(getListGroupsMethodHelper())
-                      .addMethod(getGetGroupMethodHelper())
-                      .addMethod(getCreateGroupMethodHelper())
-                      .addMethod(getUpdateGroupMethodHelper())
-                      .addMethod(getDeleteGroupMethodHelper())
-                      .addMethod(getListGroupMembersMethodHelper())
+                      .addMethod(getListGroupsMethod())
+                      .addMethod(getGetGroupMethod())
+                      .addMethod(getCreateGroupMethod())
+                      .addMethod(getUpdateGroupMethod())
+                      .addMethod(getDeleteGroupMethod())
+                      .addMethod(getListGroupMembersMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/MetricServiceGrpc.java
+++ b/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/MetricServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/monitoring/v3/metric_service.proto")
 public final class MetricServiceGrpc {
 
@@ -40,31 +40,20 @@ public final class MetricServiceGrpc {
   public static final String SERVICE_NAME = "google.monitoring.v3.MetricService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListMonitoredResourceDescriptorsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest,
-          com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
-      METHOD_LIST_MONITORED_RESOURCE_DESCRIPTORS =
-          getListMonitoredResourceDescriptorsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest,
           com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
       getListMonitoredResourceDescriptorsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListMonitoredResourceDescriptors",
+      requestType = com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest.class,
+      responseType = com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest,
           com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
       getListMonitoredResourceDescriptorsMethod() {
-    return getListMonitoredResourceDescriptorsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest,
-          com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
-      getListMonitoredResourceDescriptorsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest,
             com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
@@ -84,9 +73,7 @@ public final class MetricServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService",
-                              "ListMonitoredResourceDescriptors"))
+                          generateFullMethodName(SERVICE_NAME, "ListMonitoredResourceDescriptors"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -106,30 +93,20 @@ public final class MetricServiceGrpc {
     return getListMonitoredResourceDescriptorsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetMonitoredResourceDescriptorMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest,
-          com.google.api.MonitoredResourceDescriptor>
-      METHOD_GET_MONITORED_RESOURCE_DESCRIPTOR = getGetMonitoredResourceDescriptorMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest,
           com.google.api.MonitoredResourceDescriptor>
       getGetMonitoredResourceDescriptorMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetMonitoredResourceDescriptor",
+      requestType = com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest.class,
+      responseType = com.google.api.MonitoredResourceDescriptor.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest,
           com.google.api.MonitoredResourceDescriptor>
       getGetMonitoredResourceDescriptorMethod() {
-    return getGetMonitoredResourceDescriptorMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest,
-          com.google.api.MonitoredResourceDescriptor>
-      getGetMonitoredResourceDescriptorMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest,
             com.google.api.MonitoredResourceDescriptor>
@@ -149,9 +126,7 @@ public final class MetricServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService",
-                              "GetMonitoredResourceDescriptor"))
+                          generateFullMethodName(SERVICE_NAME, "GetMonitoredResourceDescriptor"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -170,30 +145,20 @@ public final class MetricServiceGrpc {
     return getGetMonitoredResourceDescriptorMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListMetricDescriptorsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListMetricDescriptorsRequest,
-          com.google.monitoring.v3.ListMetricDescriptorsResponse>
-      METHOD_LIST_METRIC_DESCRIPTORS = getListMetricDescriptorsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListMetricDescriptorsRequest,
           com.google.monitoring.v3.ListMetricDescriptorsResponse>
       getListMetricDescriptorsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListMetricDescriptors",
+      requestType = com.google.monitoring.v3.ListMetricDescriptorsRequest.class,
+      responseType = com.google.monitoring.v3.ListMetricDescriptorsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListMetricDescriptorsRequest,
           com.google.monitoring.v3.ListMetricDescriptorsResponse>
       getListMetricDescriptorsMethod() {
-    return getListMetricDescriptorsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListMetricDescriptorsRequest,
-          com.google.monitoring.v3.ListMetricDescriptorsResponse>
-      getListMetricDescriptorsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListMetricDescriptorsRequest,
             com.google.monitoring.v3.ListMetricDescriptorsResponse>
@@ -211,8 +176,7 @@ public final class MetricServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService", "ListMetricDescriptors"))
+                          generateFullMethodName(SERVICE_NAME, "ListMetricDescriptors"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -231,26 +195,18 @@ public final class MetricServiceGrpc {
     return getListMetricDescriptorsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetMetricDescriptorMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetMetricDescriptorRequest, com.google.api.MetricDescriptor>
-      METHOD_GET_METRIC_DESCRIPTOR = getGetMetricDescriptorMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetMetricDescriptorRequest, com.google.api.MetricDescriptor>
       getGetMetricDescriptorMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetMetricDescriptor",
+      requestType = com.google.monitoring.v3.GetMetricDescriptorRequest.class,
+      responseType = com.google.api.MetricDescriptor.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetMetricDescriptorRequest, com.google.api.MetricDescriptor>
       getGetMetricDescriptorMethod() {
-    return getGetMetricDescriptorMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetMetricDescriptorRequest, com.google.api.MetricDescriptor>
-      getGetMetricDescriptorMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetMetricDescriptorRequest, com.google.api.MetricDescriptor>
         getGetMetricDescriptorMethod;
@@ -266,8 +222,7 @@ public final class MetricServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService", "GetMetricDescriptor"))
+                          generateFullMethodName(SERVICE_NAME, "GetMetricDescriptor"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -285,26 +240,18 @@ public final class MetricServiceGrpc {
     return getGetMetricDescriptorMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateMetricDescriptorMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateMetricDescriptorRequest, com.google.api.MetricDescriptor>
-      METHOD_CREATE_METRIC_DESCRIPTOR = getCreateMetricDescriptorMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateMetricDescriptorRequest, com.google.api.MetricDescriptor>
       getCreateMetricDescriptorMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateMetricDescriptor",
+      requestType = com.google.monitoring.v3.CreateMetricDescriptorRequest.class,
+      responseType = com.google.api.MetricDescriptor.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateMetricDescriptorRequest, com.google.api.MetricDescriptor>
       getCreateMetricDescriptorMethod() {
-    return getCreateMetricDescriptorMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateMetricDescriptorRequest, com.google.api.MetricDescriptor>
-      getCreateMetricDescriptorMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateMetricDescriptorRequest, com.google.api.MetricDescriptor>
         getCreateMetricDescriptorMethod;
@@ -321,8 +268,7 @@ public final class MetricServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService", "CreateMetricDescriptor"))
+                          generateFullMethodName(SERVICE_NAME, "CreateMetricDescriptor"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -340,26 +286,18 @@ public final class MetricServiceGrpc {
     return getCreateMetricDescriptorMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteMetricDescriptorMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteMetricDescriptorRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_METRIC_DESCRIPTOR = getDeleteMetricDescriptorMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteMetricDescriptorRequest, com.google.protobuf.Empty>
       getDeleteMetricDescriptorMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteMetricDescriptor",
+      requestType = com.google.monitoring.v3.DeleteMetricDescriptorRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteMetricDescriptorRequest, com.google.protobuf.Empty>
       getDeleteMetricDescriptorMethod() {
-    return getDeleteMetricDescriptorMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteMetricDescriptorRequest, com.google.protobuf.Empty>
-      getDeleteMetricDescriptorMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.DeleteMetricDescriptorRequest, com.google.protobuf.Empty>
         getDeleteMetricDescriptorMethod;
@@ -376,8 +314,7 @@ public final class MetricServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService", "DeleteMetricDescriptor"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteMetricDescriptor"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -395,30 +332,20 @@ public final class MetricServiceGrpc {
     return getDeleteMetricDescriptorMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListTimeSeriesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListTimeSeriesRequest,
-          com.google.monitoring.v3.ListTimeSeriesResponse>
-      METHOD_LIST_TIME_SERIES = getListTimeSeriesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListTimeSeriesRequest,
           com.google.monitoring.v3.ListTimeSeriesResponse>
       getListTimeSeriesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListTimeSeries",
+      requestType = com.google.monitoring.v3.ListTimeSeriesRequest.class,
+      responseType = com.google.monitoring.v3.ListTimeSeriesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListTimeSeriesRequest,
           com.google.monitoring.v3.ListTimeSeriesResponse>
       getListTimeSeriesMethod() {
-    return getListTimeSeriesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListTimeSeriesRequest,
-          com.google.monitoring.v3.ListTimeSeriesResponse>
-      getListTimeSeriesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListTimeSeriesRequest,
             com.google.monitoring.v3.ListTimeSeriesResponse>
@@ -433,9 +360,7 @@ public final class MetricServiceGrpc {
                           com.google.monitoring.v3.ListTimeSeriesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService", "ListTimeSeries"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTimeSeries"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -452,26 +377,18 @@ public final class MetricServiceGrpc {
     return getListTimeSeriesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateTimeSeriesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>
-      METHOD_CREATE_TIME_SERIES = getCreateTimeSeriesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>
       getCreateTimeSeriesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateTimeSeries",
+      requestType = com.google.monitoring.v3.CreateTimeSeriesRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>
       getCreateTimeSeriesMethod() {
-    return getCreateTimeSeriesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>
-      getCreateTimeSeriesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>
         getCreateTimeSeriesMethod;
@@ -484,9 +401,7 @@ public final class MetricServiceGrpc {
                       .<com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.MetricService", "CreateTimeSeries"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateTimeSeries"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -506,19 +421,43 @@ public final class MetricServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static MetricServiceStub newStub(io.grpc.Channel channel) {
-    return new MetricServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<MetricServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<MetricServiceStub>() {
+          @java.lang.Override
+          public MetricServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new MetricServiceStub(channel, callOptions);
+          }
+        };
+    return MetricServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static MetricServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new MetricServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<MetricServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<MetricServiceBlockingStub>() {
+          @java.lang.Override
+          public MetricServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new MetricServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return MetricServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static MetricServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new MetricServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<MetricServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<MetricServiceFutureStub>() {
+          @java.lang.Override
+          public MetricServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new MetricServiceFutureStub(channel, callOptions);
+          }
+        };
+    return MetricServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -543,8 +482,7 @@ public final class MetricServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getListMonitoredResourceDescriptorsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListMonitoredResourceDescriptorsMethod(), responseObserver);
     }
 
     /**
@@ -557,8 +495,7 @@ public final class MetricServiceGrpc {
     public void getMonitoredResourceDescriptor(
         com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.api.MonitoredResourceDescriptor> responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getGetMonitoredResourceDescriptorMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetMonitoredResourceDescriptorMethod(), responseObserver);
     }
 
     /**
@@ -572,7 +509,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.ListMetricDescriptorsRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListMetricDescriptorsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListMetricDescriptorsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListMetricDescriptorsMethod(), responseObserver);
     }
 
     /**
@@ -585,7 +522,7 @@ public final class MetricServiceGrpc {
     public void getMetricDescriptor(
         com.google.monitoring.v3.GetMetricDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.api.MetricDescriptor> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetMetricDescriptorMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetMetricDescriptorMethod(), responseObserver);
     }
 
     /**
@@ -600,7 +537,7 @@ public final class MetricServiceGrpc {
     public void createMetricDescriptor(
         com.google.monitoring.v3.CreateMetricDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.api.MetricDescriptor> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateMetricDescriptorMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateMetricDescriptorMethod(), responseObserver);
     }
 
     /**
@@ -615,7 +552,7 @@ public final class MetricServiceGrpc {
     public void deleteMetricDescriptor(
         com.google.monitoring.v3.DeleteMetricDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteMetricDescriptorMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteMetricDescriptorMethod(), responseObserver);
     }
 
     /**
@@ -629,7 +566,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.ListTimeSeriesRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListTimeSeriesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListTimeSeriesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListTimeSeriesMethod(), responseObserver);
     }
 
     /**
@@ -645,60 +582,60 @@ public final class MetricServiceGrpc {
     public void createTimeSeries(
         com.google.monitoring.v3.CreateTimeSeriesRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateTimeSeriesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateTimeSeriesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListMonitoredResourceDescriptorsMethodHelper(),
+              getListMonitoredResourceDescriptorsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest,
                       com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>(
                       this, METHODID_LIST_MONITORED_RESOURCE_DESCRIPTORS)))
           .addMethod(
-              getGetMonitoredResourceDescriptorMethodHelper(),
+              getGetMonitoredResourceDescriptorMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest,
                       com.google.api.MonitoredResourceDescriptor>(
                       this, METHODID_GET_MONITORED_RESOURCE_DESCRIPTOR)))
           .addMethod(
-              getListMetricDescriptorsMethodHelper(),
+              getListMetricDescriptorsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListMetricDescriptorsRequest,
                       com.google.monitoring.v3.ListMetricDescriptorsResponse>(
                       this, METHODID_LIST_METRIC_DESCRIPTORS)))
           .addMethod(
-              getGetMetricDescriptorMethodHelper(),
+              getGetMetricDescriptorMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetMetricDescriptorRequest,
                       com.google.api.MetricDescriptor>(this, METHODID_GET_METRIC_DESCRIPTOR)))
           .addMethod(
-              getCreateMetricDescriptorMethodHelper(),
+              getCreateMetricDescriptorMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateMetricDescriptorRequest,
                       com.google.api.MetricDescriptor>(this, METHODID_CREATE_METRIC_DESCRIPTOR)))
           .addMethod(
-              getDeleteMetricDescriptorMethodHelper(),
+              getDeleteMetricDescriptorMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteMetricDescriptorRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_METRIC_DESCRIPTOR)))
           .addMethod(
-              getListTimeSeriesMethodHelper(),
+              getListTimeSeriesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListTimeSeriesRequest,
                       com.google.monitoring.v3.ListTimeSeriesResponse>(
                       this, METHODID_LIST_TIME_SERIES)))
           .addMethod(
-              getCreateTimeSeriesMethodHelper(),
+              getCreateTimeSeriesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateTimeSeriesRequest, com.google.protobuf.Empty>(
@@ -715,11 +652,8 @@ public final class MetricServiceGrpc {
    * time series data.
    * </pre>
    */
-  public static final class MetricServiceStub extends io.grpc.stub.AbstractStub<MetricServiceStub> {
-    private MetricServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class MetricServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<MetricServiceStub> {
     private MetricServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -742,7 +676,7 @@ public final class MetricServiceGrpc {
                 com.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListMonitoredResourceDescriptorsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListMonitoredResourceDescriptorsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -758,7 +692,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.api.MonitoredResourceDescriptor> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetMonitoredResourceDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetMonitoredResourceDescriptorMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -775,7 +709,7 @@ public final class MetricServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListMetricDescriptorsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListMetricDescriptorsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListMetricDescriptorsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -791,7 +725,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.GetMetricDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.api.MetricDescriptor> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetMetricDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetMetricDescriptorMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -809,7 +743,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.CreateMetricDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.api.MetricDescriptor> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateMetricDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateMetricDescriptorMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -827,7 +761,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.DeleteMetricDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteMetricDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteMetricDescriptorMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -844,7 +778,7 @@ public final class MetricServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListTimeSeriesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListTimeSeriesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListTimeSeriesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -863,7 +797,7 @@ public final class MetricServiceGrpc {
         com.google.monitoring.v3.CreateTimeSeriesRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateTimeSeriesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateTimeSeriesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -878,11 +812,7 @@ public final class MetricServiceGrpc {
    * </pre>
    */
   public static final class MetricServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<MetricServiceBlockingStub> {
-    private MetricServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<MetricServiceBlockingStub> {
     private MetricServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -904,10 +834,7 @@ public final class MetricServiceGrpc {
         listMonitoredResourceDescriptors(
             com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest request) {
       return blockingUnaryCall(
-          getChannel(),
-          getListMonitoredResourceDescriptorsMethodHelper(),
-          getCallOptions(),
-          request);
+          getChannel(), getListMonitoredResourceDescriptorsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -920,7 +847,7 @@ public final class MetricServiceGrpc {
     public com.google.api.MonitoredResourceDescriptor getMonitoredResourceDescriptor(
         com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetMonitoredResourceDescriptorMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetMonitoredResourceDescriptorMethod(), getCallOptions(), request);
     }
 
     /**
@@ -933,7 +860,7 @@ public final class MetricServiceGrpc {
     public com.google.monitoring.v3.ListMetricDescriptorsResponse listMetricDescriptors(
         com.google.monitoring.v3.ListMetricDescriptorsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListMetricDescriptorsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListMetricDescriptorsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -946,7 +873,7 @@ public final class MetricServiceGrpc {
     public com.google.api.MetricDescriptor getMetricDescriptor(
         com.google.monitoring.v3.GetMetricDescriptorRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetMetricDescriptorMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetMetricDescriptorMethod(), getCallOptions(), request);
     }
 
     /**
@@ -961,7 +888,7 @@ public final class MetricServiceGrpc {
     public com.google.api.MetricDescriptor createMetricDescriptor(
         com.google.monitoring.v3.CreateMetricDescriptorRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateMetricDescriptorMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateMetricDescriptorMethod(), getCallOptions(), request);
     }
 
     /**
@@ -976,7 +903,7 @@ public final class MetricServiceGrpc {
     public com.google.protobuf.Empty deleteMetricDescriptor(
         com.google.monitoring.v3.DeleteMetricDescriptorRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteMetricDescriptorMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteMetricDescriptorMethod(), getCallOptions(), request);
     }
 
     /**
@@ -988,8 +915,7 @@ public final class MetricServiceGrpc {
      */
     public com.google.monitoring.v3.ListTimeSeriesResponse listTimeSeries(
         com.google.monitoring.v3.ListTimeSeriesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListTimeSeriesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListTimeSeriesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1005,7 +931,7 @@ public final class MetricServiceGrpc {
     public com.google.protobuf.Empty createTimeSeries(
         com.google.monitoring.v3.CreateTimeSeriesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateTimeSeriesMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateTimeSeriesMethod(), getCallOptions(), request);
     }
   }
 
@@ -1018,11 +944,7 @@ public final class MetricServiceGrpc {
    * </pre>
    */
   public static final class MetricServiceFutureStub
-      extends io.grpc.stub.AbstractStub<MetricServiceFutureStub> {
-    private MetricServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<MetricServiceFutureStub> {
     private MetricServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1045,7 +967,7 @@ public final class MetricServiceGrpc {
         listMonitoredResourceDescriptors(
             com.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListMonitoredResourceDescriptorsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListMonitoredResourceDescriptorsMethod(), getCallOptions()),
           request);
     }
 
@@ -1061,7 +983,7 @@ public final class MetricServiceGrpc {
         getMonitoredResourceDescriptor(
             com.google.monitoring.v3.GetMonitoredResourceDescriptorRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetMonitoredResourceDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetMonitoredResourceDescriptorMethod(), getCallOptions()),
           request);
     }
 
@@ -1076,7 +998,7 @@ public final class MetricServiceGrpc {
             com.google.monitoring.v3.ListMetricDescriptorsResponse>
         listMetricDescriptors(com.google.monitoring.v3.ListMetricDescriptorsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListMetricDescriptorsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListMetricDescriptorsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1089,7 +1011,7 @@ public final class MetricServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.api.MetricDescriptor>
         getMetricDescriptor(com.google.monitoring.v3.GetMetricDescriptorRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetMetricDescriptorMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetMetricDescriptorMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1104,7 +1026,7 @@ public final class MetricServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.api.MetricDescriptor>
         createMetricDescriptor(com.google.monitoring.v3.CreateMetricDescriptorRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateMetricDescriptorMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateMetricDescriptorMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1119,7 +1041,7 @@ public final class MetricServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteMetricDescriptor(com.google.monitoring.v3.DeleteMetricDescriptorRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteMetricDescriptorMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteMetricDescriptorMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1133,7 +1055,7 @@ public final class MetricServiceGrpc {
             com.google.monitoring.v3.ListTimeSeriesResponse>
         listTimeSeries(com.google.monitoring.v3.ListTimeSeriesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListTimeSeriesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListTimeSeriesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1149,7 +1071,7 @@ public final class MetricServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         createTimeSeries(com.google.monitoring.v3.CreateTimeSeriesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateTimeSeriesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateTimeSeriesMethod(), getCallOptions()), request);
     }
   }
 
@@ -1288,14 +1210,14 @@ public final class MetricServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new MetricServiceFileDescriptorSupplier())
-                      .addMethod(getListMonitoredResourceDescriptorsMethodHelper())
-                      .addMethod(getGetMonitoredResourceDescriptorMethodHelper())
-                      .addMethod(getListMetricDescriptorsMethodHelper())
-                      .addMethod(getGetMetricDescriptorMethodHelper())
-                      .addMethod(getCreateMetricDescriptorMethodHelper())
-                      .addMethod(getDeleteMetricDescriptorMethodHelper())
-                      .addMethod(getListTimeSeriesMethodHelper())
-                      .addMethod(getCreateTimeSeriesMethodHelper())
+                      .addMethod(getListMonitoredResourceDescriptorsMethod())
+                      .addMethod(getGetMonitoredResourceDescriptorMethod())
+                      .addMethod(getListMetricDescriptorsMethod())
+                      .addMethod(getGetMetricDescriptorMethod())
+                      .addMethod(getCreateMetricDescriptorMethod())
+                      .addMethod(getDeleteMetricDescriptorMethod())
+                      .addMethod(getListTimeSeriesMethod())
+                      .addMethod(getCreateTimeSeriesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/NotificationChannelServiceGrpc.java
+++ b/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/NotificationChannelServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/monitoring/v3/notification_service.proto")
 public final class NotificationChannelServiceGrpc {
 
@@ -40,31 +40,20 @@ public final class NotificationChannelServiceGrpc {
   public static final String SERVICE_NAME = "google.monitoring.v3.NotificationChannelService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListNotificationChannelDescriptorsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest,
-          com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
-      METHOD_LIST_NOTIFICATION_CHANNEL_DESCRIPTORS =
-          getListNotificationChannelDescriptorsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest,
           com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
       getListNotificationChannelDescriptorsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListNotificationChannelDescriptors",
+      requestType = com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest.class,
+      responseType = com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest,
           com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
       getListNotificationChannelDescriptorsMethod() {
-    return getListNotificationChannelDescriptorsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest,
-          com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
-      getListNotificationChannelDescriptorsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest,
             com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
@@ -85,8 +74,7 @@ public final class NotificationChannelServiceGrpc {
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
                           generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "ListNotificationChannelDescriptors"))
+                              SERVICE_NAME, "ListNotificationChannelDescriptors"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -106,31 +94,20 @@ public final class NotificationChannelServiceGrpc {
     return getListNotificationChannelDescriptorsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetNotificationChannelDescriptorMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetNotificationChannelDescriptorRequest,
-          com.google.monitoring.v3.NotificationChannelDescriptor>
-      METHOD_GET_NOTIFICATION_CHANNEL_DESCRIPTOR =
-          getGetNotificationChannelDescriptorMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetNotificationChannelDescriptorRequest,
           com.google.monitoring.v3.NotificationChannelDescriptor>
       getGetNotificationChannelDescriptorMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetNotificationChannelDescriptor",
+      requestType = com.google.monitoring.v3.GetNotificationChannelDescriptorRequest.class,
+      responseType = com.google.monitoring.v3.NotificationChannelDescriptor.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetNotificationChannelDescriptorRequest,
           com.google.monitoring.v3.NotificationChannelDescriptor>
       getGetNotificationChannelDescriptorMethod() {
-    return getGetNotificationChannelDescriptorMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetNotificationChannelDescriptorRequest,
-          com.google.monitoring.v3.NotificationChannelDescriptor>
-      getGetNotificationChannelDescriptorMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetNotificationChannelDescriptorRequest,
             com.google.monitoring.v3.NotificationChannelDescriptor>
@@ -150,9 +127,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "GetNotificationChannelDescriptor"))
+                          generateFullMethodName(SERVICE_NAME, "GetNotificationChannelDescriptor"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -172,30 +147,20 @@ public final class NotificationChannelServiceGrpc {
     return getGetNotificationChannelDescriptorMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListNotificationChannelsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListNotificationChannelsRequest,
-          com.google.monitoring.v3.ListNotificationChannelsResponse>
-      METHOD_LIST_NOTIFICATION_CHANNELS = getListNotificationChannelsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListNotificationChannelsRequest,
           com.google.monitoring.v3.ListNotificationChannelsResponse>
       getListNotificationChannelsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListNotificationChannels",
+      requestType = com.google.monitoring.v3.ListNotificationChannelsRequest.class,
+      responseType = com.google.monitoring.v3.ListNotificationChannelsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListNotificationChannelsRequest,
           com.google.monitoring.v3.ListNotificationChannelsResponse>
       getListNotificationChannelsMethod() {
-    return getListNotificationChannelsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListNotificationChannelsRequest,
-          com.google.monitoring.v3.ListNotificationChannelsResponse>
-      getListNotificationChannelsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListNotificationChannelsRequest,
             com.google.monitoring.v3.ListNotificationChannelsResponse>
@@ -215,9 +180,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "ListNotificationChannels"))
+                          generateFullMethodName(SERVICE_NAME, "ListNotificationChannels"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -237,30 +200,20 @@ public final class NotificationChannelServiceGrpc {
     return getListNotificationChannelsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetNotificationChannelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      METHOD_GET_NOTIFICATION_CHANNEL = getGetNotificationChannelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getGetNotificationChannelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetNotificationChannel",
+      requestType = com.google.monitoring.v3.GetNotificationChannelRequest.class,
+      responseType = com.google.monitoring.v3.NotificationChannel.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getGetNotificationChannelMethod() {
-    return getGetNotificationChannelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      getGetNotificationChannelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetNotificationChannelRequest,
             com.google.monitoring.v3.NotificationChannel>
@@ -280,9 +233,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "GetNotificationChannel"))
+                          generateFullMethodName(SERVICE_NAME, "GetNotificationChannel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -301,30 +252,20 @@ public final class NotificationChannelServiceGrpc {
     return getGetNotificationChannelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateNotificationChannelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      METHOD_CREATE_NOTIFICATION_CHANNEL = getCreateNotificationChannelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getCreateNotificationChannelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateNotificationChannel",
+      requestType = com.google.monitoring.v3.CreateNotificationChannelRequest.class,
+      responseType = com.google.monitoring.v3.NotificationChannel.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getCreateNotificationChannelMethod() {
-    return getCreateNotificationChannelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      getCreateNotificationChannelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateNotificationChannelRequest,
             com.google.monitoring.v3.NotificationChannel>
@@ -344,9 +285,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "CreateNotificationChannel"))
+                          generateFullMethodName(SERVICE_NAME, "CreateNotificationChannel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -365,30 +304,20 @@ public final class NotificationChannelServiceGrpc {
     return getCreateNotificationChannelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateNotificationChannelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      METHOD_UPDATE_NOTIFICATION_CHANNEL = getUpdateNotificationChannelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getUpdateNotificationChannelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateNotificationChannel",
+      requestType = com.google.monitoring.v3.UpdateNotificationChannelRequest.class,
+      responseType = com.google.monitoring.v3.NotificationChannel.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getUpdateNotificationChannelMethod() {
-    return getUpdateNotificationChannelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      getUpdateNotificationChannelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.UpdateNotificationChannelRequest,
             com.google.monitoring.v3.NotificationChannel>
@@ -408,9 +337,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "UpdateNotificationChannel"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateNotificationChannel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -429,26 +356,18 @@ public final class NotificationChannelServiceGrpc {
     return getUpdateNotificationChannelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteNotificationChannelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteNotificationChannelRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_NOTIFICATION_CHANNEL = getDeleteNotificationChannelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteNotificationChannelRequest, com.google.protobuf.Empty>
       getDeleteNotificationChannelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteNotificationChannel",
+      requestType = com.google.monitoring.v3.DeleteNotificationChannelRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteNotificationChannelRequest, com.google.protobuf.Empty>
       getDeleteNotificationChannelMethod() {
-    return getDeleteNotificationChannelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteNotificationChannelRequest, com.google.protobuf.Empty>
-      getDeleteNotificationChannelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.DeleteNotificationChannelRequest, com.google.protobuf.Empty>
         getDeleteNotificationChannelMethod;
@@ -467,9 +386,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "DeleteNotificationChannel"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteNotificationChannel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -488,31 +405,20 @@ public final class NotificationChannelServiceGrpc {
     return getDeleteNotificationChannelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSendNotificationChannelVerificationCodeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest,
-          com.google.protobuf.Empty>
-      METHOD_SEND_NOTIFICATION_CHANNEL_VERIFICATION_CODE =
-          getSendNotificationChannelVerificationCodeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest,
           com.google.protobuf.Empty>
       getSendNotificationChannelVerificationCodeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SendNotificationChannelVerificationCode",
+      requestType = com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest,
           com.google.protobuf.Empty>
       getSendNotificationChannelVerificationCodeMethod() {
-    return getSendNotificationChannelVerificationCodeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest,
-          com.google.protobuf.Empty>
-      getSendNotificationChannelVerificationCodeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest,
             com.google.protobuf.Empty>
@@ -533,8 +439,7 @@ public final class NotificationChannelServiceGrpc {
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
                           generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "SendNotificationChannelVerificationCode"))
+                              SERVICE_NAME, "SendNotificationChannelVerificationCode"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -554,31 +459,20 @@ public final class NotificationChannelServiceGrpc {
     return getSendNotificationChannelVerificationCodeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetNotificationChannelVerificationCodeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest,
-          com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
-      METHOD_GET_NOTIFICATION_CHANNEL_VERIFICATION_CODE =
-          getGetNotificationChannelVerificationCodeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest,
           com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
       getGetNotificationChannelVerificationCodeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetNotificationChannelVerificationCode",
+      requestType = com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest.class,
+      responseType = com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest,
           com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
       getGetNotificationChannelVerificationCodeMethod() {
-    return getGetNotificationChannelVerificationCodeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest,
-          com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
-      getGetNotificationChannelVerificationCodeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest,
             com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
@@ -599,8 +493,7 @@ public final class NotificationChannelServiceGrpc {
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
                           generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "GetNotificationChannelVerificationCode"))
+                              SERVICE_NAME, "GetNotificationChannelVerificationCode"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -621,30 +514,20 @@ public final class NotificationChannelServiceGrpc {
     return getGetNotificationChannelVerificationCodeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getVerifyNotificationChannelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.VerifyNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      METHOD_VERIFY_NOTIFICATION_CHANNEL = getVerifyNotificationChannelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.VerifyNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getVerifyNotificationChannelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "VerifyNotificationChannel",
+      requestType = com.google.monitoring.v3.VerifyNotificationChannelRequest.class,
+      responseType = com.google.monitoring.v3.NotificationChannel.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.VerifyNotificationChannelRequest,
           com.google.monitoring.v3.NotificationChannel>
       getVerifyNotificationChannelMethod() {
-    return getVerifyNotificationChannelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.VerifyNotificationChannelRequest,
-          com.google.monitoring.v3.NotificationChannel>
-      getVerifyNotificationChannelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.VerifyNotificationChannelRequest,
             com.google.monitoring.v3.NotificationChannel>
@@ -664,9 +547,7 @@ public final class NotificationChannelServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.NotificationChannelService",
-                              "VerifyNotificationChannel"))
+                          generateFullMethodName(SERVICE_NAME, "VerifyNotificationChannel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -687,19 +568,43 @@ public final class NotificationChannelServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static NotificationChannelServiceStub newStub(io.grpc.Channel channel) {
-    return new NotificationChannelServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<NotificationChannelServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<NotificationChannelServiceStub>() {
+          @java.lang.Override
+          public NotificationChannelServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new NotificationChannelServiceStub(channel, callOptions);
+          }
+        };
+    return NotificationChannelServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static NotificationChannelServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new NotificationChannelServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<NotificationChannelServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<NotificationChannelServiceBlockingStub>() {
+          @java.lang.Override
+          public NotificationChannelServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new NotificationChannelServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return NotificationChannelServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static NotificationChannelServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new NotificationChannelServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<NotificationChannelServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<NotificationChannelServiceFutureStub>() {
+          @java.lang.Override
+          public NotificationChannelServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new NotificationChannelServiceFutureStub(channel, callOptions);
+          }
+        };
+    return NotificationChannelServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -726,8 +631,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getListNotificationChannelDescriptorsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListNotificationChannelDescriptorsMethod(), responseObserver);
     }
 
     /**
@@ -742,8 +646,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.GetNotificationChannelDescriptorRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannelDescriptor>
             responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getGetNotificationChannelDescriptorMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetNotificationChannelDescriptorMethod(), responseObserver);
     }
 
     /**
@@ -757,7 +660,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.ListNotificationChannelsRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListNotificationChannelsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListNotificationChannelsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListNotificationChannelsMethod(), responseObserver);
     }
 
     /**
@@ -775,7 +678,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.GetNotificationChannelRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetNotificationChannelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetNotificationChannelMethod(), responseObserver);
     }
 
     /**
@@ -790,7 +693,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.CreateNotificationChannelRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateNotificationChannelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateNotificationChannelMethod(), responseObserver);
     }
 
     /**
@@ -805,7 +708,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.UpdateNotificationChannelRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateNotificationChannelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateNotificationChannelMethod(), responseObserver);
     }
 
     /**
@@ -818,7 +721,7 @@ public final class NotificationChannelServiceGrpc {
     public void deleteNotificationChannel(
         com.google.monitoring.v3.DeleteNotificationChannelRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteNotificationChannelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteNotificationChannelMethod(), responseObserver);
     }
 
     /**
@@ -833,7 +736,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnimplementedUnaryCall(
-          getSendNotificationChannelVerificationCodeMethodHelper(), responseObserver);
+          getSendNotificationChannelVerificationCodeMethod(), responseObserver);
     }
 
     /**
@@ -868,7 +771,7 @@ public final class NotificationChannelServiceGrpc {
                 com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
             responseObserver) {
       asyncUnimplementedUnaryCall(
-          getGetNotificationChannelVerificationCodeMethodHelper(), responseObserver);
+          getGetNotificationChannelVerificationCodeMethod(), responseObserver);
     }
 
     /**
@@ -884,76 +787,76 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.VerifyNotificationChannelRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getVerifyNotificationChannelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getVerifyNotificationChannelMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListNotificationChannelDescriptorsMethodHelper(),
+              getListNotificationChannelDescriptorsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest,
                       com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>(
                       this, METHODID_LIST_NOTIFICATION_CHANNEL_DESCRIPTORS)))
           .addMethod(
-              getGetNotificationChannelDescriptorMethodHelper(),
+              getGetNotificationChannelDescriptorMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetNotificationChannelDescriptorRequest,
                       com.google.monitoring.v3.NotificationChannelDescriptor>(
                       this, METHODID_GET_NOTIFICATION_CHANNEL_DESCRIPTOR)))
           .addMethod(
-              getListNotificationChannelsMethodHelper(),
+              getListNotificationChannelsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListNotificationChannelsRequest,
                       com.google.monitoring.v3.ListNotificationChannelsResponse>(
                       this, METHODID_LIST_NOTIFICATION_CHANNELS)))
           .addMethod(
-              getGetNotificationChannelMethodHelper(),
+              getGetNotificationChannelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetNotificationChannelRequest,
                       com.google.monitoring.v3.NotificationChannel>(
                       this, METHODID_GET_NOTIFICATION_CHANNEL)))
           .addMethod(
-              getCreateNotificationChannelMethodHelper(),
+              getCreateNotificationChannelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateNotificationChannelRequest,
                       com.google.monitoring.v3.NotificationChannel>(
                       this, METHODID_CREATE_NOTIFICATION_CHANNEL)))
           .addMethod(
-              getUpdateNotificationChannelMethodHelper(),
+              getUpdateNotificationChannelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.UpdateNotificationChannelRequest,
                       com.google.monitoring.v3.NotificationChannel>(
                       this, METHODID_UPDATE_NOTIFICATION_CHANNEL)))
           .addMethod(
-              getDeleteNotificationChannelMethodHelper(),
+              getDeleteNotificationChannelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteNotificationChannelRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_NOTIFICATION_CHANNEL)))
           .addMethod(
-              getSendNotificationChannelVerificationCodeMethodHelper(),
+              getSendNotificationChannelVerificationCodeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest,
                       com.google.protobuf.Empty>(
                       this, METHODID_SEND_NOTIFICATION_CHANNEL_VERIFICATION_CODE)))
           .addMethod(
-              getGetNotificationChannelVerificationCodeMethodHelper(),
+              getGetNotificationChannelVerificationCodeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest,
                       com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>(
                       this, METHODID_GET_NOTIFICATION_CHANNEL_VERIFICATION_CODE)))
           .addMethod(
-              getVerifyNotificationChannelMethodHelper(),
+              getVerifyNotificationChannelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.VerifyNotificationChannelRequest,
@@ -972,11 +875,7 @@ public final class NotificationChannelServiceGrpc {
    * </pre>
    */
   public static final class NotificationChannelServiceStub
-      extends io.grpc.stub.AbstractStub<NotificationChannelServiceStub> {
-    private NotificationChannelServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<NotificationChannelServiceStub> {
     private NotificationChannelServiceStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1002,8 +901,7 @@ public final class NotificationChannelServiceGrpc {
                 com.google.monitoring.v3.ListNotificationChannelDescriptorsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel()
-              .newCall(getListNotificationChannelDescriptorsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListNotificationChannelDescriptorsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1021,7 +919,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannelDescriptor>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetNotificationChannelDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationChannelDescriptorMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1038,7 +936,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListNotificationChannelsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListNotificationChannelsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListNotificationChannelsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1059,7 +957,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetNotificationChannelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationChannelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1077,7 +975,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateNotificationChannelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateNotificationChannelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1095,7 +993,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateNotificationChannelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateNotificationChannelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1111,7 +1009,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.DeleteNotificationChannelRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteNotificationChannelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteNotificationChannelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1129,7 +1027,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
           getChannel()
-              .newCall(getSendNotificationChannelVerificationCodeMethodHelper(), getCallOptions()),
+              .newCall(getSendNotificationChannelVerificationCodeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1166,8 +1064,7 @@ public final class NotificationChannelServiceGrpc {
                 com.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel()
-              .newCall(getGetNotificationChannelVerificationCodeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationChannelVerificationCodeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1186,7 +1083,7 @@ public final class NotificationChannelServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.NotificationChannel>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getVerifyNotificationChannelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getVerifyNotificationChannelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1201,11 +1098,7 @@ public final class NotificationChannelServiceGrpc {
    * </pre>
    */
   public static final class NotificationChannelServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<NotificationChannelServiceBlockingStub> {
-    private NotificationChannelServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<NotificationChannelServiceBlockingStub> {
     private NotificationChannelServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1229,10 +1122,7 @@ public final class NotificationChannelServiceGrpc {
         listNotificationChannelDescriptors(
             com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest request) {
       return blockingUnaryCall(
-          getChannel(),
-          getListNotificationChannelDescriptorsMethodHelper(),
-          getCallOptions(),
-          request);
+          getChannel(), getListNotificationChannelDescriptorsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1246,10 +1136,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.monitoring.v3.NotificationChannelDescriptor getNotificationChannelDescriptor(
         com.google.monitoring.v3.GetNotificationChannelDescriptorRequest request) {
       return blockingUnaryCall(
-          getChannel(),
-          getGetNotificationChannelDescriptorMethodHelper(),
-          getCallOptions(),
-          request);
+          getChannel(), getGetNotificationChannelDescriptorMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1262,7 +1149,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.monitoring.v3.ListNotificationChannelsResponse listNotificationChannels(
         com.google.monitoring.v3.ListNotificationChannelsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListNotificationChannelsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListNotificationChannelsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1279,7 +1166,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.monitoring.v3.NotificationChannel getNotificationChannel(
         com.google.monitoring.v3.GetNotificationChannelRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetNotificationChannelMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetNotificationChannelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1293,7 +1180,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.monitoring.v3.NotificationChannel createNotificationChannel(
         com.google.monitoring.v3.CreateNotificationChannelRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateNotificationChannelMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateNotificationChannelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1307,7 +1194,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.monitoring.v3.NotificationChannel updateNotificationChannel(
         com.google.monitoring.v3.UpdateNotificationChannelRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateNotificationChannelMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateNotificationChannelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1320,7 +1207,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.protobuf.Empty deleteNotificationChannel(
         com.google.monitoring.v3.DeleteNotificationChannelRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteNotificationChannelMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteNotificationChannelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1335,7 +1222,7 @@ public final class NotificationChannelServiceGrpc {
         com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest request) {
       return blockingUnaryCall(
           getChannel(),
-          getSendNotificationChannelVerificationCodeMethodHelper(),
+          getSendNotificationChannelVerificationCodeMethod(),
           getCallOptions(),
           request);
     }
@@ -1371,7 +1258,7 @@ public final class NotificationChannelServiceGrpc {
             com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest request) {
       return blockingUnaryCall(
           getChannel(),
-          getGetNotificationChannelVerificationCodeMethodHelper(),
+          getGetNotificationChannelVerificationCodeMethod(),
           getCallOptions(),
           request);
     }
@@ -1388,7 +1275,7 @@ public final class NotificationChannelServiceGrpc {
     public com.google.monitoring.v3.NotificationChannel verifyNotificationChannel(
         com.google.monitoring.v3.VerifyNotificationChannelRequest request) {
       return blockingUnaryCall(
-          getChannel(), getVerifyNotificationChannelMethodHelper(), getCallOptions(), request);
+          getChannel(), getVerifyNotificationChannelMethod(), getCallOptions(), request);
     }
   }
 
@@ -1401,11 +1288,7 @@ public final class NotificationChannelServiceGrpc {
    * </pre>
    */
   public static final class NotificationChannelServiceFutureStub
-      extends io.grpc.stub.AbstractStub<NotificationChannelServiceFutureStub> {
-    private NotificationChannelServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<NotificationChannelServiceFutureStub> {
     private NotificationChannelServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1430,8 +1313,7 @@ public final class NotificationChannelServiceGrpc {
         listNotificationChannelDescriptors(
             com.google.monitoring.v3.ListNotificationChannelDescriptorsRequest request) {
       return futureUnaryCall(
-          getChannel()
-              .newCall(getListNotificationChannelDescriptorsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListNotificationChannelDescriptorsMethod(), getCallOptions()),
           request);
     }
 
@@ -1448,7 +1330,7 @@ public final class NotificationChannelServiceGrpc {
         getNotificationChannelDescriptor(
             com.google.monitoring.v3.GetNotificationChannelDescriptorRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetNotificationChannelDescriptorMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationChannelDescriptorMethod(), getCallOptions()),
           request);
     }
 
@@ -1463,8 +1345,7 @@ public final class NotificationChannelServiceGrpc {
             com.google.monitoring.v3.ListNotificationChannelsResponse>
         listNotificationChannels(com.google.monitoring.v3.ListNotificationChannelsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListNotificationChannelsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListNotificationChannelsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1482,7 +1363,7 @@ public final class NotificationChannelServiceGrpc {
             com.google.monitoring.v3.NotificationChannel>
         getNotificationChannel(com.google.monitoring.v3.GetNotificationChannelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetNotificationChannelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetNotificationChannelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1498,8 +1379,7 @@ public final class NotificationChannelServiceGrpc {
         createNotificationChannel(
             com.google.monitoring.v3.CreateNotificationChannelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateNotificationChannelMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateNotificationChannelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1515,8 +1395,7 @@ public final class NotificationChannelServiceGrpc {
         updateNotificationChannel(
             com.google.monitoring.v3.UpdateNotificationChannelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateNotificationChannelMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateNotificationChannelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1530,8 +1409,7 @@ public final class NotificationChannelServiceGrpc {
         deleteNotificationChannel(
             com.google.monitoring.v3.DeleteNotificationChannelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteNotificationChannelMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteNotificationChannelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1547,7 +1425,7 @@ public final class NotificationChannelServiceGrpc {
             com.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest request) {
       return futureUnaryCall(
           getChannel()
-              .newCall(getSendNotificationChannelVerificationCodeMethodHelper(), getCallOptions()),
+              .newCall(getSendNotificationChannelVerificationCodeMethod(), getCallOptions()),
           request);
     }
 
@@ -1582,8 +1460,7 @@ public final class NotificationChannelServiceGrpc {
         getNotificationChannelVerificationCode(
             com.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest request) {
       return futureUnaryCall(
-          getChannel()
-              .newCall(getGetNotificationChannelVerificationCodeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationChannelVerificationCodeMethod(), getCallOptions()),
           request);
     }
 
@@ -1601,8 +1478,7 @@ public final class NotificationChannelServiceGrpc {
         verifyNotificationChannel(
             com.google.monitoring.v3.VerifyNotificationChannelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getVerifyNotificationChannelMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getVerifyNotificationChannelMethod(), getCallOptions()), request);
     }
   }
 
@@ -1759,16 +1635,16 @@ public final class NotificationChannelServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new NotificationChannelServiceFileDescriptorSupplier())
-                      .addMethod(getListNotificationChannelDescriptorsMethodHelper())
-                      .addMethod(getGetNotificationChannelDescriptorMethodHelper())
-                      .addMethod(getListNotificationChannelsMethodHelper())
-                      .addMethod(getGetNotificationChannelMethodHelper())
-                      .addMethod(getCreateNotificationChannelMethodHelper())
-                      .addMethod(getUpdateNotificationChannelMethodHelper())
-                      .addMethod(getDeleteNotificationChannelMethodHelper())
-                      .addMethod(getSendNotificationChannelVerificationCodeMethodHelper())
-                      .addMethod(getGetNotificationChannelVerificationCodeMethodHelper())
-                      .addMethod(getVerifyNotificationChannelMethodHelper())
+                      .addMethod(getListNotificationChannelDescriptorsMethod())
+                      .addMethod(getGetNotificationChannelDescriptorMethod())
+                      .addMethod(getListNotificationChannelsMethod())
+                      .addMethod(getGetNotificationChannelMethod())
+                      .addMethod(getCreateNotificationChannelMethod())
+                      .addMethod(getUpdateNotificationChannelMethod())
+                      .addMethod(getDeleteNotificationChannelMethod())
+                      .addMethod(getSendNotificationChannelVerificationCodeMethod())
+                      .addMethod(getGetNotificationChannelVerificationCodeMethod())
+                      .addMethod(getVerifyNotificationChannelMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/ServiceMonitoringServiceGrpc.java
+++ b/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/ServiceMonitoringServiceGrpc.java
@@ -33,7 +33,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/monitoring/v3/service_service.proto")
 public final class ServiceMonitoringServiceGrpc {
 
@@ -42,26 +42,18 @@ public final class ServiceMonitoringServiceGrpc {
   public static final String SERVICE_NAME = "google.monitoring.v3.ServiceMonitoringService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateServiceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateServiceRequest, com.google.monitoring.v3.Service>
-      METHOD_CREATE_SERVICE = getCreateServiceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateServiceRequest, com.google.monitoring.v3.Service>
       getCreateServiceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateService",
+      requestType = com.google.monitoring.v3.CreateServiceRequest.class,
+      responseType = com.google.monitoring.v3.Service.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateServiceRequest, com.google.monitoring.v3.Service>
       getCreateServiceMethod() {
-    return getCreateServiceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateServiceRequest, com.google.monitoring.v3.Service>
-      getCreateServiceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateServiceRequest, com.google.monitoring.v3.Service>
         getCreateServiceMethod;
@@ -76,9 +68,7 @@ public final class ServiceMonitoringServiceGrpc {
                           com.google.monitoring.v3.Service>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService", "CreateService"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateService"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -95,26 +85,18 @@ public final class ServiceMonitoringServiceGrpc {
     return getCreateServiceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetServiceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetServiceRequest, com.google.monitoring.v3.Service>
-      METHOD_GET_SERVICE = getGetServiceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetServiceRequest, com.google.monitoring.v3.Service>
       getGetServiceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetService",
+      requestType = com.google.monitoring.v3.GetServiceRequest.class,
+      responseType = com.google.monitoring.v3.Service.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetServiceRequest, com.google.monitoring.v3.Service>
       getGetServiceMethod() {
-    return getGetServiceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetServiceRequest, com.google.monitoring.v3.Service>
-      getGetServiceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetServiceRequest, com.google.monitoring.v3.Service>
         getGetServiceMethod;
@@ -128,9 +110,7 @@ public final class ServiceMonitoringServiceGrpc {
                           com.google.monitoring.v3.Service>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService", "GetService"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetService"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -147,30 +127,20 @@ public final class ServiceMonitoringServiceGrpc {
     return getGetServiceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListServicesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListServicesRequest,
-          com.google.monitoring.v3.ListServicesResponse>
-      METHOD_LIST_SERVICES = getListServicesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListServicesRequest,
           com.google.monitoring.v3.ListServicesResponse>
       getListServicesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListServices",
+      requestType = com.google.monitoring.v3.ListServicesRequest.class,
+      responseType = com.google.monitoring.v3.ListServicesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListServicesRequest,
           com.google.monitoring.v3.ListServicesResponse>
       getListServicesMethod() {
-    return getListServicesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListServicesRequest,
-          com.google.monitoring.v3.ListServicesResponse>
-      getListServicesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListServicesRequest,
             com.google.monitoring.v3.ListServicesResponse>
@@ -185,9 +155,7 @@ public final class ServiceMonitoringServiceGrpc {
                           com.google.monitoring.v3.ListServicesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService", "ListServices"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListServices"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -204,26 +172,18 @@ public final class ServiceMonitoringServiceGrpc {
     return getListServicesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateServiceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateServiceRequest, com.google.monitoring.v3.Service>
-      METHOD_UPDATE_SERVICE = getUpdateServiceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateServiceRequest, com.google.monitoring.v3.Service>
       getUpdateServiceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateService",
+      requestType = com.google.monitoring.v3.UpdateServiceRequest.class,
+      responseType = com.google.monitoring.v3.Service.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateServiceRequest, com.google.monitoring.v3.Service>
       getUpdateServiceMethod() {
-    return getUpdateServiceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateServiceRequest, com.google.monitoring.v3.Service>
-      getUpdateServiceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.UpdateServiceRequest, com.google.monitoring.v3.Service>
         getUpdateServiceMethod;
@@ -238,9 +198,7 @@ public final class ServiceMonitoringServiceGrpc {
                           com.google.monitoring.v3.Service>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService", "UpdateService"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateService"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -257,26 +215,18 @@ public final class ServiceMonitoringServiceGrpc {
     return getUpdateServiceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteServiceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_SERVICE = getDeleteServiceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>
       getDeleteServiceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteService",
+      requestType = com.google.monitoring.v3.DeleteServiceRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>
       getDeleteServiceMethod() {
-    return getDeleteServiceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>
-      getDeleteServiceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>
         getDeleteServiceMethod;
@@ -290,9 +240,7 @@ public final class ServiceMonitoringServiceGrpc {
                       .<com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService", "DeleteService"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteService"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -309,30 +257,20 @@ public final class ServiceMonitoringServiceGrpc {
     return getDeleteServiceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateServiceLevelObjectiveMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateServiceLevelObjectiveRequest,
-          com.google.monitoring.v3.ServiceLevelObjective>
-      METHOD_CREATE_SERVICE_LEVEL_OBJECTIVE = getCreateServiceLevelObjectiveMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateServiceLevelObjectiveRequest,
           com.google.monitoring.v3.ServiceLevelObjective>
       getCreateServiceLevelObjectiveMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateServiceLevelObjective",
+      requestType = com.google.monitoring.v3.CreateServiceLevelObjectiveRequest.class,
+      responseType = com.google.monitoring.v3.ServiceLevelObjective.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateServiceLevelObjectiveRequest,
           com.google.monitoring.v3.ServiceLevelObjective>
       getCreateServiceLevelObjectiveMethod() {
-    return getCreateServiceLevelObjectiveMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateServiceLevelObjectiveRequest,
-          com.google.monitoring.v3.ServiceLevelObjective>
-      getCreateServiceLevelObjectiveMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateServiceLevelObjectiveRequest,
             com.google.monitoring.v3.ServiceLevelObjective>
@@ -352,9 +290,7 @@ public final class ServiceMonitoringServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService",
-                              "CreateServiceLevelObjective"))
+                          generateFullMethodName(SERVICE_NAME, "CreateServiceLevelObjective"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -373,30 +309,20 @@ public final class ServiceMonitoringServiceGrpc {
     return getCreateServiceLevelObjectiveMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetServiceLevelObjectiveMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetServiceLevelObjectiveRequest,
-          com.google.monitoring.v3.ServiceLevelObjective>
-      METHOD_GET_SERVICE_LEVEL_OBJECTIVE = getGetServiceLevelObjectiveMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetServiceLevelObjectiveRequest,
           com.google.monitoring.v3.ServiceLevelObjective>
       getGetServiceLevelObjectiveMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetServiceLevelObjective",
+      requestType = com.google.monitoring.v3.GetServiceLevelObjectiveRequest.class,
+      responseType = com.google.monitoring.v3.ServiceLevelObjective.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetServiceLevelObjectiveRequest,
           com.google.monitoring.v3.ServiceLevelObjective>
       getGetServiceLevelObjectiveMethod() {
-    return getGetServiceLevelObjectiveMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetServiceLevelObjectiveRequest,
-          com.google.monitoring.v3.ServiceLevelObjective>
-      getGetServiceLevelObjectiveMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetServiceLevelObjectiveRequest,
             com.google.monitoring.v3.ServiceLevelObjective>
@@ -416,9 +342,7 @@ public final class ServiceMonitoringServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService",
-                              "GetServiceLevelObjective"))
+                          generateFullMethodName(SERVICE_NAME, "GetServiceLevelObjective"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -437,30 +361,20 @@ public final class ServiceMonitoringServiceGrpc {
     return getGetServiceLevelObjectiveMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListServiceLevelObjectivesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListServiceLevelObjectivesRequest,
-          com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
-      METHOD_LIST_SERVICE_LEVEL_OBJECTIVES = getListServiceLevelObjectivesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListServiceLevelObjectivesRequest,
           com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
       getListServiceLevelObjectivesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListServiceLevelObjectives",
+      requestType = com.google.monitoring.v3.ListServiceLevelObjectivesRequest.class,
+      responseType = com.google.monitoring.v3.ListServiceLevelObjectivesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListServiceLevelObjectivesRequest,
           com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
       getListServiceLevelObjectivesMethod() {
-    return getListServiceLevelObjectivesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListServiceLevelObjectivesRequest,
-          com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
-      getListServiceLevelObjectivesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListServiceLevelObjectivesRequest,
             com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
@@ -480,9 +394,7 @@ public final class ServiceMonitoringServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService",
-                              "ListServiceLevelObjectives"))
+                          generateFullMethodName(SERVICE_NAME, "ListServiceLevelObjectives"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -502,30 +414,20 @@ public final class ServiceMonitoringServiceGrpc {
     return getListServiceLevelObjectivesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateServiceLevelObjectiveMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest,
-          com.google.monitoring.v3.ServiceLevelObjective>
-      METHOD_UPDATE_SERVICE_LEVEL_OBJECTIVE = getUpdateServiceLevelObjectiveMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest,
           com.google.monitoring.v3.ServiceLevelObjective>
       getUpdateServiceLevelObjectiveMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateServiceLevelObjective",
+      requestType = com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest.class,
+      responseType = com.google.monitoring.v3.ServiceLevelObjective.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest,
           com.google.monitoring.v3.ServiceLevelObjective>
       getUpdateServiceLevelObjectiveMethod() {
-    return getUpdateServiceLevelObjectiveMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest,
-          com.google.monitoring.v3.ServiceLevelObjective>
-      getUpdateServiceLevelObjectiveMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest,
             com.google.monitoring.v3.ServiceLevelObjective>
@@ -545,9 +447,7 @@ public final class ServiceMonitoringServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService",
-                              "UpdateServiceLevelObjective"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateServiceLevelObjective"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -566,26 +466,18 @@ public final class ServiceMonitoringServiceGrpc {
     return getUpdateServiceLevelObjectiveMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteServiceLevelObjectiveMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_SERVICE_LEVEL_OBJECTIVE = getDeleteServiceLevelObjectiveMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest, com.google.protobuf.Empty>
       getDeleteServiceLevelObjectiveMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteServiceLevelObjective",
+      requestType = com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest, com.google.protobuf.Empty>
       getDeleteServiceLevelObjectiveMethod() {
-    return getDeleteServiceLevelObjectiveMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest, com.google.protobuf.Empty>
-      getDeleteServiceLevelObjectiveMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest, com.google.protobuf.Empty>
         getDeleteServiceLevelObjectiveMethod;
@@ -604,9 +496,7 @@ public final class ServiceMonitoringServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.ServiceMonitoringService",
-                              "DeleteServiceLevelObjective"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteServiceLevelObjective"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -627,19 +517,43 @@ public final class ServiceMonitoringServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ServiceMonitoringServiceStub newStub(io.grpc.Channel channel) {
-    return new ServiceMonitoringServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ServiceMonitoringServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ServiceMonitoringServiceStub>() {
+          @java.lang.Override
+          public ServiceMonitoringServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ServiceMonitoringServiceStub(channel, callOptions);
+          }
+        };
+    return ServiceMonitoringServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ServiceMonitoringServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ServiceMonitoringServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ServiceMonitoringServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ServiceMonitoringServiceBlockingStub>() {
+          @java.lang.Override
+          public ServiceMonitoringServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ServiceMonitoringServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return ServiceMonitoringServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ServiceMonitoringServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ServiceMonitoringServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ServiceMonitoringServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ServiceMonitoringServiceFutureStub>() {
+          @java.lang.Override
+          public ServiceMonitoringServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ServiceMonitoringServiceFutureStub(channel, callOptions);
+          }
+        };
+    return ServiceMonitoringServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -664,7 +578,7 @@ public final class ServiceMonitoringServiceGrpc {
     public void createService(
         com.google.monitoring.v3.CreateServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Service> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateServiceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateServiceMethod(), responseObserver);
     }
 
     /**
@@ -677,7 +591,7 @@ public final class ServiceMonitoringServiceGrpc {
     public void getService(
         com.google.monitoring.v3.GetServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Service> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetServiceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetServiceMethod(), responseObserver);
     }
 
     /**
@@ -691,7 +605,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.ListServicesRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListServicesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListServicesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListServicesMethod(), responseObserver);
     }
 
     /**
@@ -704,7 +618,7 @@ public final class ServiceMonitoringServiceGrpc {
     public void updateService(
         com.google.monitoring.v3.UpdateServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Service> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateServiceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateServiceMethod(), responseObserver);
     }
 
     /**
@@ -717,7 +631,7 @@ public final class ServiceMonitoringServiceGrpc {
     public void deleteService(
         com.google.monitoring.v3.DeleteServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteServiceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteServiceMethod(), responseObserver);
     }
 
     /**
@@ -731,7 +645,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.CreateServiceLevelObjectiveRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ServiceLevelObjective>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateServiceLevelObjectiveMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateServiceLevelObjectiveMethod(), responseObserver);
     }
 
     /**
@@ -745,7 +659,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.GetServiceLevelObjectiveRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ServiceLevelObjective>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetServiceLevelObjectiveMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetServiceLevelObjectiveMethod(), responseObserver);
     }
 
     /**
@@ -759,7 +673,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.ListServiceLevelObjectivesRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListServiceLevelObjectivesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListServiceLevelObjectivesMethod(), responseObserver);
     }
 
     /**
@@ -773,7 +687,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ServiceLevelObjective>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateServiceLevelObjectiveMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateServiceLevelObjectiveMethod(), responseObserver);
     }
 
     /**
@@ -786,72 +700,72 @@ public final class ServiceMonitoringServiceGrpc {
     public void deleteServiceLevelObjective(
         com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteServiceLevelObjectiveMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteServiceLevelObjectiveMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateServiceMethodHelper(),
+              getCreateServiceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateServiceRequest,
                       com.google.monitoring.v3.Service>(this, METHODID_CREATE_SERVICE)))
           .addMethod(
-              getGetServiceMethodHelper(),
+              getGetServiceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetServiceRequest, com.google.monitoring.v3.Service>(
                       this, METHODID_GET_SERVICE)))
           .addMethod(
-              getListServicesMethodHelper(),
+              getListServicesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListServicesRequest,
                       com.google.monitoring.v3.ListServicesResponse>(this, METHODID_LIST_SERVICES)))
           .addMethod(
-              getUpdateServiceMethodHelper(),
+              getUpdateServiceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.UpdateServiceRequest,
                       com.google.monitoring.v3.Service>(this, METHODID_UPDATE_SERVICE)))
           .addMethod(
-              getDeleteServiceMethodHelper(),
+              getDeleteServiceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteServiceRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_SERVICE)))
           .addMethod(
-              getCreateServiceLevelObjectiveMethodHelper(),
+              getCreateServiceLevelObjectiveMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateServiceLevelObjectiveRequest,
                       com.google.monitoring.v3.ServiceLevelObjective>(
                       this, METHODID_CREATE_SERVICE_LEVEL_OBJECTIVE)))
           .addMethod(
-              getGetServiceLevelObjectiveMethodHelper(),
+              getGetServiceLevelObjectiveMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetServiceLevelObjectiveRequest,
                       com.google.monitoring.v3.ServiceLevelObjective>(
                       this, METHODID_GET_SERVICE_LEVEL_OBJECTIVE)))
           .addMethod(
-              getListServiceLevelObjectivesMethodHelper(),
+              getListServiceLevelObjectivesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListServiceLevelObjectivesRequest,
                       com.google.monitoring.v3.ListServiceLevelObjectivesResponse>(
                       this, METHODID_LIST_SERVICE_LEVEL_OBJECTIVES)))
           .addMethod(
-              getUpdateServiceLevelObjectiveMethodHelper(),
+              getUpdateServiceLevelObjectiveMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest,
                       com.google.monitoring.v3.ServiceLevelObjective>(
                       this, METHODID_UPDATE_SERVICE_LEVEL_OBJECTIVE)))
           .addMethod(
-              getDeleteServiceLevelObjectiveMethodHelper(),
+              getDeleteServiceLevelObjectiveMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest,
@@ -871,11 +785,7 @@ public final class ServiceMonitoringServiceGrpc {
    * </pre>
    */
   public static final class ServiceMonitoringServiceStub
-      extends io.grpc.stub.AbstractStub<ServiceMonitoringServiceStub> {
-    private ServiceMonitoringServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ServiceMonitoringServiceStub> {
     private ServiceMonitoringServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -897,7 +807,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.CreateServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Service> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateServiceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateServiceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -913,9 +823,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.GetServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Service> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetServiceMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetServiceMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -930,7 +838,7 @@ public final class ServiceMonitoringServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListServicesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListServicesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListServicesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -946,7 +854,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.UpdateServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.Service> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateServiceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateServiceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -962,7 +870,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.DeleteServiceRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteServiceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteServiceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -979,7 +887,7 @@ public final class ServiceMonitoringServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ServiceLevelObjective>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateServiceLevelObjectiveMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateServiceLevelObjectiveMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -996,7 +904,7 @@ public final class ServiceMonitoringServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ServiceLevelObjective>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetServiceLevelObjectiveMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetServiceLevelObjectiveMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1013,7 +921,7 @@ public final class ServiceMonitoringServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListServiceLevelObjectivesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListServiceLevelObjectivesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListServiceLevelObjectivesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1030,7 +938,7 @@ public final class ServiceMonitoringServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ServiceLevelObjective>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateServiceLevelObjectiveMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateServiceLevelObjectiveMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1046,7 +954,7 @@ public final class ServiceMonitoringServiceGrpc {
         com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteServiceLevelObjectiveMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteServiceLevelObjectiveMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1063,11 +971,7 @@ public final class ServiceMonitoringServiceGrpc {
    * </pre>
    */
   public static final class ServiceMonitoringServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<ServiceMonitoringServiceBlockingStub> {
-    private ServiceMonitoringServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ServiceMonitoringServiceBlockingStub> {
     private ServiceMonitoringServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1088,8 +992,7 @@ public final class ServiceMonitoringServiceGrpc {
      */
     public com.google.monitoring.v3.Service createService(
         com.google.monitoring.v3.CreateServiceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateServiceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateServiceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1101,8 +1004,7 @@ public final class ServiceMonitoringServiceGrpc {
      */
     public com.google.monitoring.v3.Service getService(
         com.google.monitoring.v3.GetServiceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetServiceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetServiceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1114,8 +1016,7 @@ public final class ServiceMonitoringServiceGrpc {
      */
     public com.google.monitoring.v3.ListServicesResponse listServices(
         com.google.monitoring.v3.ListServicesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListServicesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListServicesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1127,8 +1028,7 @@ public final class ServiceMonitoringServiceGrpc {
      */
     public com.google.monitoring.v3.Service updateService(
         com.google.monitoring.v3.UpdateServiceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateServiceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateServiceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1140,8 +1040,7 @@ public final class ServiceMonitoringServiceGrpc {
      */
     public com.google.protobuf.Empty deleteService(
         com.google.monitoring.v3.DeleteServiceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteServiceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteServiceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1154,7 +1053,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.monitoring.v3.ServiceLevelObjective createServiceLevelObjective(
         com.google.monitoring.v3.CreateServiceLevelObjectiveRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateServiceLevelObjectiveMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateServiceLevelObjectiveMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1167,7 +1066,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.monitoring.v3.ServiceLevelObjective getServiceLevelObjective(
         com.google.monitoring.v3.GetServiceLevelObjectiveRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetServiceLevelObjectiveMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetServiceLevelObjectiveMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1180,7 +1079,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.monitoring.v3.ListServiceLevelObjectivesResponse listServiceLevelObjectives(
         com.google.monitoring.v3.ListServiceLevelObjectivesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListServiceLevelObjectivesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListServiceLevelObjectivesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1193,7 +1092,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.monitoring.v3.ServiceLevelObjective updateServiceLevelObjective(
         com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateServiceLevelObjectiveMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateServiceLevelObjectiveMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1206,7 +1105,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.protobuf.Empty deleteServiceLevelObjective(
         com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteServiceLevelObjectiveMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteServiceLevelObjectiveMethod(), getCallOptions(), request);
     }
   }
 
@@ -1221,11 +1120,7 @@ public final class ServiceMonitoringServiceGrpc {
    * </pre>
    */
   public static final class ServiceMonitoringServiceFutureStub
-      extends io.grpc.stub.AbstractStub<ServiceMonitoringServiceFutureStub> {
-    private ServiceMonitoringServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ServiceMonitoringServiceFutureStub> {
     private ServiceMonitoringServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1247,7 +1142,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.Service>
         createService(com.google.monitoring.v3.CreateServiceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateServiceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateServiceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1260,7 +1155,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.Service>
         getService(com.google.monitoring.v3.GetServiceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetServiceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetServiceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1274,7 +1169,7 @@ public final class ServiceMonitoringServiceGrpc {
             com.google.monitoring.v3.ListServicesResponse>
         listServices(com.google.monitoring.v3.ListServicesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListServicesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListServicesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1287,7 +1182,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.monitoring.v3.Service>
         updateService(com.google.monitoring.v3.UpdateServiceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateServiceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateServiceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1300,7 +1195,7 @@ public final class ServiceMonitoringServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteService(com.google.monitoring.v3.DeleteServiceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteServiceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteServiceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1315,8 +1210,7 @@ public final class ServiceMonitoringServiceGrpc {
         createServiceLevelObjective(
             com.google.monitoring.v3.CreateServiceLevelObjectiveRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateServiceLevelObjectiveMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateServiceLevelObjectiveMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1330,8 +1224,7 @@ public final class ServiceMonitoringServiceGrpc {
             com.google.monitoring.v3.ServiceLevelObjective>
         getServiceLevelObjective(com.google.monitoring.v3.GetServiceLevelObjectiveRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetServiceLevelObjectiveMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getGetServiceLevelObjectiveMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1346,8 +1239,7 @@ public final class ServiceMonitoringServiceGrpc {
         listServiceLevelObjectives(
             com.google.monitoring.v3.ListServiceLevelObjectivesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListServiceLevelObjectivesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListServiceLevelObjectivesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1362,8 +1254,7 @@ public final class ServiceMonitoringServiceGrpc {
         updateServiceLevelObjective(
             com.google.monitoring.v3.UpdateServiceLevelObjectiveRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateServiceLevelObjectiveMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateServiceLevelObjectiveMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1377,8 +1268,7 @@ public final class ServiceMonitoringServiceGrpc {
         deleteServiceLevelObjective(
             com.google.monitoring.v3.DeleteServiceLevelObjectiveRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteServiceLevelObjectiveMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteServiceLevelObjectiveMethod(), getCallOptions()), request);
     }
   }
 
@@ -1530,16 +1420,16 @@ public final class ServiceMonitoringServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ServiceMonitoringServiceFileDescriptorSupplier())
-                      .addMethod(getCreateServiceMethodHelper())
-                      .addMethod(getGetServiceMethodHelper())
-                      .addMethod(getListServicesMethodHelper())
-                      .addMethod(getUpdateServiceMethodHelper())
-                      .addMethod(getDeleteServiceMethodHelper())
-                      .addMethod(getCreateServiceLevelObjectiveMethodHelper())
-                      .addMethod(getGetServiceLevelObjectiveMethodHelper())
-                      .addMethod(getListServiceLevelObjectivesMethodHelper())
-                      .addMethod(getUpdateServiceLevelObjectiveMethodHelper())
-                      .addMethod(getDeleteServiceLevelObjectiveMethodHelper())
+                      .addMethod(getCreateServiceMethod())
+                      .addMethod(getGetServiceMethod())
+                      .addMethod(getListServicesMethod())
+                      .addMethod(getUpdateServiceMethod())
+                      .addMethod(getDeleteServiceMethod())
+                      .addMethod(getCreateServiceLevelObjectiveMethod())
+                      .addMethod(getGetServiceLevelObjectiveMethod())
+                      .addMethod(getListServiceLevelObjectivesMethod())
+                      .addMethod(getUpdateServiceLevelObjectiveMethod())
+                      .addMethod(getDeleteServiceLevelObjectiveMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/UptimeCheckServiceGrpc.java
+++ b/grpc-google-cloud-monitoring-v3/src/main/java/com/google/monitoring/v3/UptimeCheckServiceGrpc.java
@@ -37,7 +37,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/monitoring/v3/uptime_service.proto")
 public final class UptimeCheckServiceGrpc {
 
@@ -46,30 +46,20 @@ public final class UptimeCheckServiceGrpc {
   public static final String SERVICE_NAME = "google.monitoring.v3.UptimeCheckService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListUptimeCheckConfigsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListUptimeCheckConfigsRequest,
-          com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
-      METHOD_LIST_UPTIME_CHECK_CONFIGS = getListUptimeCheckConfigsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListUptimeCheckConfigsRequest,
           com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
       getListUptimeCheckConfigsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListUptimeCheckConfigs",
+      requestType = com.google.monitoring.v3.ListUptimeCheckConfigsRequest.class,
+      responseType = com.google.monitoring.v3.ListUptimeCheckConfigsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListUptimeCheckConfigsRequest,
           com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
       getListUptimeCheckConfigsMethod() {
-    return getListUptimeCheckConfigsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListUptimeCheckConfigsRequest,
-          com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
-      getListUptimeCheckConfigsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListUptimeCheckConfigsRequest,
             com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
@@ -88,8 +78,7 @@ public final class UptimeCheckServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.UptimeCheckService", "ListUptimeCheckConfigs"))
+                          generateFullMethodName(SERVICE_NAME, "ListUptimeCheckConfigs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -108,30 +97,20 @@ public final class UptimeCheckServiceGrpc {
     return getListUptimeCheckConfigsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetUptimeCheckConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetUptimeCheckConfigRequest,
-          com.google.monitoring.v3.UptimeCheckConfig>
-      METHOD_GET_UPTIME_CHECK_CONFIG = getGetUptimeCheckConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetUptimeCheckConfigRequest,
           com.google.monitoring.v3.UptimeCheckConfig>
       getGetUptimeCheckConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetUptimeCheckConfig",
+      requestType = com.google.monitoring.v3.GetUptimeCheckConfigRequest.class,
+      responseType = com.google.monitoring.v3.UptimeCheckConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.GetUptimeCheckConfigRequest,
           com.google.monitoring.v3.UptimeCheckConfig>
       getGetUptimeCheckConfigMethod() {
-    return getGetUptimeCheckConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.GetUptimeCheckConfigRequest,
-          com.google.monitoring.v3.UptimeCheckConfig>
-      getGetUptimeCheckConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.GetUptimeCheckConfigRequest,
             com.google.monitoring.v3.UptimeCheckConfig>
@@ -149,8 +128,7 @@ public final class UptimeCheckServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.UptimeCheckService", "GetUptimeCheckConfig"))
+                          generateFullMethodName(SERVICE_NAME, "GetUptimeCheckConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -168,30 +146,20 @@ public final class UptimeCheckServiceGrpc {
     return getGetUptimeCheckConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateUptimeCheckConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateUptimeCheckConfigRequest,
-          com.google.monitoring.v3.UptimeCheckConfig>
-      METHOD_CREATE_UPTIME_CHECK_CONFIG = getCreateUptimeCheckConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateUptimeCheckConfigRequest,
           com.google.monitoring.v3.UptimeCheckConfig>
       getCreateUptimeCheckConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateUptimeCheckConfig",
+      requestType = com.google.monitoring.v3.CreateUptimeCheckConfigRequest.class,
+      responseType = com.google.monitoring.v3.UptimeCheckConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.CreateUptimeCheckConfigRequest,
           com.google.monitoring.v3.UptimeCheckConfig>
       getCreateUptimeCheckConfigMethod() {
-    return getCreateUptimeCheckConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.CreateUptimeCheckConfigRequest,
-          com.google.monitoring.v3.UptimeCheckConfig>
-      getCreateUptimeCheckConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.CreateUptimeCheckConfigRequest,
             com.google.monitoring.v3.UptimeCheckConfig>
@@ -210,8 +178,7 @@ public final class UptimeCheckServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.UptimeCheckService", "CreateUptimeCheckConfig"))
+                          generateFullMethodName(SERVICE_NAME, "CreateUptimeCheckConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -229,30 +196,20 @@ public final class UptimeCheckServiceGrpc {
     return getCreateUptimeCheckConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateUptimeCheckConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateUptimeCheckConfigRequest,
-          com.google.monitoring.v3.UptimeCheckConfig>
-      METHOD_UPDATE_UPTIME_CHECK_CONFIG = getUpdateUptimeCheckConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateUptimeCheckConfigRequest,
           com.google.monitoring.v3.UptimeCheckConfig>
       getUpdateUptimeCheckConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateUptimeCheckConfig",
+      requestType = com.google.monitoring.v3.UpdateUptimeCheckConfigRequest.class,
+      responseType = com.google.monitoring.v3.UptimeCheckConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.UpdateUptimeCheckConfigRequest,
           com.google.monitoring.v3.UptimeCheckConfig>
       getUpdateUptimeCheckConfigMethod() {
-    return getUpdateUptimeCheckConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.UpdateUptimeCheckConfigRequest,
-          com.google.monitoring.v3.UptimeCheckConfig>
-      getUpdateUptimeCheckConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.UpdateUptimeCheckConfigRequest,
             com.google.monitoring.v3.UptimeCheckConfig>
@@ -271,8 +228,7 @@ public final class UptimeCheckServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.UptimeCheckService", "UpdateUptimeCheckConfig"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateUptimeCheckConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -290,26 +246,18 @@ public final class UptimeCheckServiceGrpc {
     return getUpdateUptimeCheckConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteUptimeCheckConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteUptimeCheckConfigRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_UPTIME_CHECK_CONFIG = getDeleteUptimeCheckConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteUptimeCheckConfigRequest, com.google.protobuf.Empty>
       getDeleteUptimeCheckConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteUptimeCheckConfig",
+      requestType = com.google.monitoring.v3.DeleteUptimeCheckConfigRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.DeleteUptimeCheckConfigRequest, com.google.protobuf.Empty>
       getDeleteUptimeCheckConfigMethod() {
-    return getDeleteUptimeCheckConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.DeleteUptimeCheckConfigRequest, com.google.protobuf.Empty>
-      getDeleteUptimeCheckConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.DeleteUptimeCheckConfigRequest, com.google.protobuf.Empty>
         getDeleteUptimeCheckConfigMethod;
@@ -327,8 +275,7 @@ public final class UptimeCheckServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.UptimeCheckService", "DeleteUptimeCheckConfig"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteUptimeCheckConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -346,30 +293,20 @@ public final class UptimeCheckServiceGrpc {
     return getDeleteUptimeCheckConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListUptimeCheckIpsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListUptimeCheckIpsRequest,
-          com.google.monitoring.v3.ListUptimeCheckIpsResponse>
-      METHOD_LIST_UPTIME_CHECK_IPS = getListUptimeCheckIpsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListUptimeCheckIpsRequest,
           com.google.monitoring.v3.ListUptimeCheckIpsResponse>
       getListUptimeCheckIpsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListUptimeCheckIps",
+      requestType = com.google.monitoring.v3.ListUptimeCheckIpsRequest.class,
+      responseType = com.google.monitoring.v3.ListUptimeCheckIpsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.monitoring.v3.ListUptimeCheckIpsRequest,
           com.google.monitoring.v3.ListUptimeCheckIpsResponse>
       getListUptimeCheckIpsMethod() {
-    return getListUptimeCheckIpsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.monitoring.v3.ListUptimeCheckIpsRequest,
-          com.google.monitoring.v3.ListUptimeCheckIpsResponse>
-      getListUptimeCheckIpsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.monitoring.v3.ListUptimeCheckIpsRequest,
             com.google.monitoring.v3.ListUptimeCheckIpsResponse>
@@ -386,9 +323,7 @@ public final class UptimeCheckServiceGrpc {
                           com.google.monitoring.v3.ListUptimeCheckIpsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.monitoring.v3.UptimeCheckService", "ListUptimeCheckIps"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListUptimeCheckIps"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -409,19 +344,43 @@ public final class UptimeCheckServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static UptimeCheckServiceStub newStub(io.grpc.Channel channel) {
-    return new UptimeCheckServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<UptimeCheckServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<UptimeCheckServiceStub>() {
+          @java.lang.Override
+          public UptimeCheckServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new UptimeCheckServiceStub(channel, callOptions);
+          }
+        };
+    return UptimeCheckServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static UptimeCheckServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new UptimeCheckServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<UptimeCheckServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<UptimeCheckServiceBlockingStub>() {
+          @java.lang.Override
+          public UptimeCheckServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new UptimeCheckServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return UptimeCheckServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static UptimeCheckServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new UptimeCheckServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<UptimeCheckServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<UptimeCheckServiceFutureStub>() {
+          @java.lang.Override
+          public UptimeCheckServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new UptimeCheckServiceFutureStub(channel, callOptions);
+          }
+        };
+    return UptimeCheckServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -452,7 +411,7 @@ public final class UptimeCheckServiceGrpc {
         com.google.monitoring.v3.ListUptimeCheckConfigsRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListUptimeCheckConfigsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListUptimeCheckConfigsMethod(), responseObserver);
     }
 
     /**
@@ -465,7 +424,7 @@ public final class UptimeCheckServiceGrpc {
     public void getUptimeCheckConfig(
         com.google.monitoring.v3.GetUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.UptimeCheckConfig> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetUptimeCheckConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetUptimeCheckConfigMethod(), responseObserver);
     }
 
     /**
@@ -478,7 +437,7 @@ public final class UptimeCheckServiceGrpc {
     public void createUptimeCheckConfig(
         com.google.monitoring.v3.CreateUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.UptimeCheckConfig> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateUptimeCheckConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateUptimeCheckConfigMethod(), responseObserver);
     }
 
     /**
@@ -494,7 +453,7 @@ public final class UptimeCheckServiceGrpc {
     public void updateUptimeCheckConfig(
         com.google.monitoring.v3.UpdateUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.UptimeCheckConfig> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateUptimeCheckConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateUptimeCheckConfigMethod(), responseObserver);
     }
 
     /**
@@ -509,7 +468,7 @@ public final class UptimeCheckServiceGrpc {
     public void deleteUptimeCheckConfig(
         com.google.monitoring.v3.DeleteUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteUptimeCheckConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteUptimeCheckConfigMethod(), responseObserver);
     }
 
     /**
@@ -523,48 +482,48 @@ public final class UptimeCheckServiceGrpc {
         com.google.monitoring.v3.ListUptimeCheckIpsRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListUptimeCheckIpsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListUptimeCheckIpsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListUptimeCheckIpsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListUptimeCheckConfigsMethodHelper(),
+              getListUptimeCheckConfigsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListUptimeCheckConfigsRequest,
                       com.google.monitoring.v3.ListUptimeCheckConfigsResponse>(
                       this, METHODID_LIST_UPTIME_CHECK_CONFIGS)))
           .addMethod(
-              getGetUptimeCheckConfigMethodHelper(),
+              getGetUptimeCheckConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.GetUptimeCheckConfigRequest,
                       com.google.monitoring.v3.UptimeCheckConfig>(
                       this, METHODID_GET_UPTIME_CHECK_CONFIG)))
           .addMethod(
-              getCreateUptimeCheckConfigMethodHelper(),
+              getCreateUptimeCheckConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.CreateUptimeCheckConfigRequest,
                       com.google.monitoring.v3.UptimeCheckConfig>(
                       this, METHODID_CREATE_UPTIME_CHECK_CONFIG)))
           .addMethod(
-              getUpdateUptimeCheckConfigMethodHelper(),
+              getUpdateUptimeCheckConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.UpdateUptimeCheckConfigRequest,
                       com.google.monitoring.v3.UptimeCheckConfig>(
                       this, METHODID_UPDATE_UPTIME_CHECK_CONFIG)))
           .addMethod(
-              getDeleteUptimeCheckConfigMethodHelper(),
+              getDeleteUptimeCheckConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.DeleteUptimeCheckConfigRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_UPTIME_CHECK_CONFIG)))
           .addMethod(
-              getListUptimeCheckIpsMethodHelper(),
+              getListUptimeCheckIpsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.monitoring.v3.ListUptimeCheckIpsRequest,
@@ -589,11 +548,7 @@ public final class UptimeCheckServiceGrpc {
    * </pre>
    */
   public static final class UptimeCheckServiceStub
-      extends io.grpc.stub.AbstractStub<UptimeCheckServiceStub> {
-    private UptimeCheckServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<UptimeCheckServiceStub> {
     private UptimeCheckServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -617,7 +572,7 @@ public final class UptimeCheckServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListUptimeCheckConfigsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListUptimeCheckConfigsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -633,7 +588,7 @@ public final class UptimeCheckServiceGrpc {
         com.google.monitoring.v3.GetUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.UptimeCheckConfig> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetUptimeCheckConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetUptimeCheckConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -649,7 +604,7 @@ public final class UptimeCheckServiceGrpc {
         com.google.monitoring.v3.CreateUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.UptimeCheckConfig> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateUptimeCheckConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateUptimeCheckConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -668,7 +623,7 @@ public final class UptimeCheckServiceGrpc {
         com.google.monitoring.v3.UpdateUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.UptimeCheckConfig> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateUptimeCheckConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateUptimeCheckConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -686,7 +641,7 @@ public final class UptimeCheckServiceGrpc {
         com.google.monitoring.v3.DeleteUptimeCheckConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteUptimeCheckConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteUptimeCheckConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -703,7 +658,7 @@ public final class UptimeCheckServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.monitoring.v3.ListUptimeCheckIpsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListUptimeCheckIpsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListUptimeCheckIpsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -724,11 +679,7 @@ public final class UptimeCheckServiceGrpc {
    * </pre>
    */
   public static final class UptimeCheckServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<UptimeCheckServiceBlockingStub> {
-    private UptimeCheckServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<UptimeCheckServiceBlockingStub> {
     private UptimeCheckServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -751,7 +702,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.monitoring.v3.ListUptimeCheckConfigsResponse listUptimeCheckConfigs(
         com.google.monitoring.v3.ListUptimeCheckConfigsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListUptimeCheckConfigsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListUptimeCheckConfigsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -764,7 +715,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.monitoring.v3.UptimeCheckConfig getUptimeCheckConfig(
         com.google.monitoring.v3.GetUptimeCheckConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetUptimeCheckConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetUptimeCheckConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -777,7 +728,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.monitoring.v3.UptimeCheckConfig createUptimeCheckConfig(
         com.google.monitoring.v3.CreateUptimeCheckConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateUptimeCheckConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateUptimeCheckConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -793,7 +744,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.monitoring.v3.UptimeCheckConfig updateUptimeCheckConfig(
         com.google.monitoring.v3.UpdateUptimeCheckConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateUptimeCheckConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateUptimeCheckConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -808,7 +759,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.protobuf.Empty deleteUptimeCheckConfig(
         com.google.monitoring.v3.DeleteUptimeCheckConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteUptimeCheckConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteUptimeCheckConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -821,7 +772,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.monitoring.v3.ListUptimeCheckIpsResponse listUptimeCheckIps(
         com.google.monitoring.v3.ListUptimeCheckIpsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListUptimeCheckIpsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListUptimeCheckIpsMethod(), getCallOptions(), request);
     }
   }
 
@@ -840,11 +791,7 @@ public final class UptimeCheckServiceGrpc {
    * </pre>
    */
   public static final class UptimeCheckServiceFutureStub
-      extends io.grpc.stub.AbstractStub<UptimeCheckServiceFutureStub> {
-    private UptimeCheckServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<UptimeCheckServiceFutureStub> {
     private UptimeCheckServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -867,7 +814,7 @@ public final class UptimeCheckServiceGrpc {
             com.google.monitoring.v3.ListUptimeCheckConfigsResponse>
         listUptimeCheckConfigs(com.google.monitoring.v3.ListUptimeCheckConfigsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListUptimeCheckConfigsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListUptimeCheckConfigsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -881,7 +828,7 @@ public final class UptimeCheckServiceGrpc {
             com.google.monitoring.v3.UptimeCheckConfig>
         getUptimeCheckConfig(com.google.monitoring.v3.GetUptimeCheckConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetUptimeCheckConfigMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetUptimeCheckConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -895,8 +842,7 @@ public final class UptimeCheckServiceGrpc {
             com.google.monitoring.v3.UptimeCheckConfig>
         createUptimeCheckConfig(com.google.monitoring.v3.CreateUptimeCheckConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateUptimeCheckConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateUptimeCheckConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -913,8 +859,7 @@ public final class UptimeCheckServiceGrpc {
             com.google.monitoring.v3.UptimeCheckConfig>
         updateUptimeCheckConfig(com.google.monitoring.v3.UpdateUptimeCheckConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateUptimeCheckConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateUptimeCheckConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -929,8 +874,7 @@ public final class UptimeCheckServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteUptimeCheckConfig(com.google.monitoring.v3.DeleteUptimeCheckConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteUptimeCheckConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteUptimeCheckConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -944,7 +888,7 @@ public final class UptimeCheckServiceGrpc {
             com.google.monitoring.v3.ListUptimeCheckIpsResponse>
         listUptimeCheckIps(com.google.monitoring.v3.ListUptimeCheckIpsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListUptimeCheckIpsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListUptimeCheckIpsMethod(), getCallOptions()), request);
     }
   }
 
@@ -1071,12 +1015,12 @@ public final class UptimeCheckServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new UptimeCheckServiceFileDescriptorSupplier())
-                      .addMethod(getListUptimeCheckConfigsMethodHelper())
-                      .addMethod(getGetUptimeCheckConfigMethodHelper())
-                      .addMethod(getCreateUptimeCheckConfigMethodHelper())
-                      .addMethod(getUpdateUptimeCheckConfigMethodHelper())
-                      .addMethod(getDeleteUptimeCheckConfigMethodHelper())
-                      .addMethod(getListUptimeCheckIpsMethodHelper())
+                      .addMethod(getListUptimeCheckConfigsMethod())
+                      .addMethod(getGetUptimeCheckConfigMethod())
+                      .addMethod(getCreateUptimeCheckConfigMethod())
+                      .addMethod(getUpdateUptimeCheckConfigMethod())
+                      .addMethod(getDeleteUptimeCheckConfigMethod())
+                      .addMethod(getListUptimeCheckIpsMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,23 +14,17 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'monitoring'
 versions = ['v3']
-config_pattern = '/google/monitoring/artman_monitoring.yaml'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern=config_pattern,
-    package_pattern='com.google.{service}.{version}',
-    gapic=gapic
+  java.bazel_library(
+      service=service,
+      version=version,
+      proto_path=f'google/{service}/{version}',
+      bazel_target=f'//google/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)
