### PR TITLE
fix: fix samples and samples tests for UptimeCheck.

### DIFF
--- a/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
+++ b/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
@@ -253,7 +253,6 @@ public class UptimeSample {
     // create UptimeCheckServiceClient with retry setting
     try (UptimeCheckServiceClient client =
         UptimeCheckServiceClient.create(uptimeCheckServiceSettings)) {
-      // String fullCheckName = UptimeCheckConfigName.format(projectId, checkId);
       UptimeCheckConfig config = client.getUptimeCheckConfig(checkName);
       if (config != null) {
         System.out.println(config.toString());

--- a/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
+++ b/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
@@ -129,8 +129,7 @@ public class UptimeSample {
         listUptimeCheckIps();
         break;
       case "get":
-        getUptimeCheckConfig(
-            cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"));
+        getUptimeCheckConfig(cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"));
         break;
       case "delete":
         deleteUptimeCheckConfig(
@@ -169,8 +168,8 @@ public class UptimeSample {
   // [END monitoring_uptime_check_create]]
 
   // [START monitoring_uptime_check_update]]
-  private static void updateUptimeCheck(
-      String checkName, String hostName, String pathName) throws IOException {
+  private static void updateUptimeCheck(String checkName, String hostName, String pathName)
+      throws IOException {
 
     UpdateUptimeCheckConfigRequest request =
         UpdateUptimeCheckConfigRequest.newBuilder()
@@ -259,8 +258,7 @@ public class UptimeSample {
       if (config != null) {
         System.out.println(config.toString());
       } else {
-        System.out.println(
-            "No uptime check config found with ID " + checkName);
+        System.out.println("No uptime check config found with ID " + checkName);
       }
     } catch (Exception e) {
       usage("Exception getting uptime check: " + e.toString());
@@ -270,8 +268,7 @@ public class UptimeSample {
   // [END monitoring_uptime_check_get]]
 
   // [START monitoring_uptime_check_delete]]
-  private static void deleteUptimeCheckConfig(String checkName)
-      throws IOException {
+  private static void deleteUptimeCheckConfig(String checkName) throws IOException {
     try (UptimeCheckServiceClient client = UptimeCheckServiceClient.create()) {
       client.deleteUptimeCheckConfig(checkName);
     } catch (Exception e) {

--- a/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
+++ b/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
@@ -95,8 +95,8 @@ public class UptimeSample {
       throw new RuntimeException("Exception parsing command line arguments.", pe);
     }
 
-    String projectId = "java-docs-samples-testing";
-        // cl.getOptionValue(PROJECT_ID_OPTION.getOpt(), System.getenv("GOOGLE_CLOUD_PROJECT"));
+    String projectId =
+        cl.getOptionValue(PROJECT_ID_OPTION.getOpt(), System.getenv("GOOGLE_CLOUD_PROJECT"));
 
     String command =
         Optional.of(cl.getArgList())

--- a/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
+++ b/samples/snippets/src/main/java/com/example/monitoring/UptimeSample.java
@@ -29,7 +29,6 @@ import com.google.monitoring.v3.ProjectName;
 import com.google.monitoring.v3.UpdateUptimeCheckConfigRequest;
 import com.google.monitoring.v3.UptimeCheckConfig;
 import com.google.monitoring.v3.UptimeCheckConfig.HttpCheck;
-import com.google.monitoring.v3.UptimeCheckConfigName;
 import com.google.monitoring.v3.UptimeCheckIp;
 import com.google.protobuf.Duration;
 import com.google.protobuf.FieldMask;
@@ -96,8 +95,8 @@ public class UptimeSample {
       throw new RuntimeException("Exception parsing command line arguments.", pe);
     }
 
-    String projectId =
-        cl.getOptionValue(PROJECT_ID_OPTION.getOpt(), System.getenv("GOOGLE_CLOUD_PROJECT"));
+    String projectId = "java-docs-samples-testing";
+        // cl.getOptionValue(PROJECT_ID_OPTION.getOpt(), System.getenv("GOOGLE_CLOUD_PROJECT"));
 
     String command =
         Optional.of(cl.getArgList())
@@ -119,7 +118,6 @@ public class UptimeSample {
         break;
       case "update":
         updateUptimeCheck(
-            projectId,
             cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"),
             cl.getOptionValue(HOST_NAME_OPTION.getOpt(), "example.com"),
             cl.getOptionValue(PATH_NAME_OPTION.getOpt(), "/"));
@@ -132,11 +130,11 @@ public class UptimeSample {
         break;
       case "get":
         getUptimeCheckConfig(
-            projectId, cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"));
+            cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"));
         break;
       case "delete":
         deleteUptimeCheckConfig(
-            projectId, cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"));
+            cl.getOptionValue(DISPLAY_NAME_OPTION.getOpt(), "new uptime check"));
         break;
       default:
         usage(null);
@@ -162,7 +160,7 @@ public class UptimeSample {
             .build();
     try (UptimeCheckServiceClient client = UptimeCheckServiceClient.create()) {
       UptimeCheckConfig config = client.createUptimeCheckConfig(request);
-      System.out.println("Uptime check created: " + config.getDisplayName());
+      System.out.println("Uptime check created: " + config.getName());
     } catch (Exception e) {
       usage("Exception creating uptime check: " + e.toString());
       throw e;
@@ -172,15 +170,14 @@ public class UptimeSample {
 
   // [START monitoring_uptime_check_update]]
   private static void updateUptimeCheck(
-      String projectId, String displayName, String hostName, String pathName) throws IOException {
-    String fullCheckName = UptimeCheckConfigName.format(projectId, displayName);
+      String checkName, String hostName, String pathName) throws IOException {
 
     UpdateUptimeCheckConfigRequest request =
         UpdateUptimeCheckConfigRequest.newBuilder()
             .setUpdateMask(FieldMask.newBuilder().addPaths("http_check.path"))
             .setUptimeCheckConfig(
                 UptimeCheckConfig.newBuilder()
-                    .setName(fullCheckName)
+                    .setName(checkName)
                     .setMonitoredResource(
                         MonitoredResource.newBuilder()
                             .setType("uptime_url")
@@ -231,7 +228,7 @@ public class UptimeSample {
   // [END monitoring_uptime_check_list_ips]]
 
   // [START monitoring_uptime_check_get]]
-  private static void getUptimeCheckConfig(String projectId, String checkName) throws IOException {
+  private static void getUptimeCheckConfig(String checkName) throws IOException {
     // Create UptimeCheckServiceSettings instance for add retry mechanism
     UptimeCheckServiceSettings.Builder uptimeCheckServiceSettingsBuilder =
         UptimeCheckServiceSettings.newBuilder();
@@ -257,13 +254,13 @@ public class UptimeSample {
     // create UptimeCheckServiceClient with retry setting
     try (UptimeCheckServiceClient client =
         UptimeCheckServiceClient.create(uptimeCheckServiceSettings)) {
-      String fullCheckName = UptimeCheckConfigName.format(projectId, checkName);
-      UptimeCheckConfig config = client.getUptimeCheckConfig(fullCheckName);
+      // String fullCheckName = UptimeCheckConfigName.format(projectId, checkId);
+      UptimeCheckConfig config = client.getUptimeCheckConfig(checkName);
       if (config != null) {
         System.out.println(config.toString());
       } else {
         System.out.println(
-            "No uptime check config found with name " + checkName + " in project " + projectId);
+            "No uptime check config found with ID " + checkName);
       }
     } catch (Exception e) {
       usage("Exception getting uptime check: " + e.toString());
@@ -273,10 +270,10 @@ public class UptimeSample {
   // [END monitoring_uptime_check_get]]
 
   // [START monitoring_uptime_check_delete]]
-  private static void deleteUptimeCheckConfig(String projectId, String checkName)
+  private static void deleteUptimeCheckConfig(String checkName)
       throws IOException {
     try (UptimeCheckServiceClient client = UptimeCheckServiceClient.create()) {
-      client.deleteUptimeCheckConfig(UptimeCheckConfigName.format(projectId, checkName));
+      client.deleteUptimeCheckConfig(checkName);
     } catch (Exception e) {
       usage("Exception deleting uptime check: " + e.toString());
       throw e;

--- a/samples/snippets/src/test/java/com/example/monitoring/UptimeIT.java
+++ b/samples/snippets/src/test/java/com/example/monitoring/UptimeIT.java
@@ -38,6 +38,7 @@ public class UptimeIT {
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
+  private static String checkName;
 
   private static UptimeCheckConfig config =
       UptimeCheckConfig.newBuilder()
@@ -62,18 +63,20 @@ public class UptimeIT {
   @Test
   public void test1_CreateUptimeCheck() throws Exception {
     UptimeSample.main("create", "-n", config.getDisplayName(), "-o", "test.example.com", "-a", "/");
-    assertThat(bout.toString()).contains("Uptime check created: " + config.getDisplayName());
+    String actual = bout.toString();
+    assertThat(actual).contains(config.getDisplayName());
+    checkName =  actual.split(":")[1].trim();
   }
 
   @Test
   public void test2_UpdateUptimeCheck() throws Exception {
-    UptimeSample.main("update", "-n", config.getDisplayName(), "-a", "/updated");
+    UptimeSample.main("update", "-n", checkName, "-a", "/updated");
     assertThat(bout.toString()).contains("/updated");
   }
 
   @Test
   public void test2_GetUptimeCheck() throws Exception {
-    UptimeSample.main("get", "-n", config.getDisplayName());
+    UptimeSample.main("get", "-n", checkName);
     assertThat(bout.toString()).contains(config.getDisplayName());
   }
 
@@ -96,6 +99,6 @@ public class UptimeIT {
 
   @Test
   public void test3_DeleteUptimeCheck() throws Exception {
-    UptimeSample.main("delete", "-n", config.getDisplayName());
+    UptimeSample.main("delete", "-n", checkName);
   }
 }

--- a/samples/snippets/src/test/java/com/example/monitoring/UptimeIT.java
+++ b/samples/snippets/src/test/java/com/example/monitoring/UptimeIT.java
@@ -65,7 +65,7 @@ public class UptimeIT {
     UptimeSample.main("create", "-n", config.getDisplayName(), "-o", "test.example.com", "-a", "/");
     String actual = bout.toString();
     assertThat(actual).contains(config.getDisplayName());
-    checkName =  actual.split(":")[1].trim();
+    checkName = actual.split(":")[1].trim();
   }
 
   @Test


### PR DESCRIPTION
UpdateUptimeCheck, GetUptimeCheck and DeleteUptimeCheck have been failing because they are not taking the correct argument, instead of passing in display name, we should pass in the full check name. Hence every time the test was triggered, a new uptime check was created but was not cleaned up correctly, eventually we reached the limit of uptime check in the testing project and CreateUptimeCheck started failing too.
fixes #850 
fixes #851 
fixes #863 
fixes #871 