### PR TITLE
fix: google-auth-library-oauth2-http is runtime scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-monitoring'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-monitoring:3.3.6'
+implementation 'com.google.cloud:google-cloud-monitoring:3.4.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-monitoring" % "3.3.6"
+libraryDependencies += "com.google.cloud" % "google-cloud-monitoring" % "3.4.0"
 ```
 
 ## Authentication

--- a/google-cloud-monitoring/pom.xml
+++ b/google-cloud-monitoring/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->
     <dependency>


### PR DESCRIPTION
Fixing https://github.com/googleapis/java-monitoring/commit/204e76cecb14a75fd27a74abe498dcd45bced6e1